### PR TITLE
docs: add workshop participants list and PR title check workflow

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,28 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows conventional commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            ci
+            perf
+            build
+            revert
+          requireScope: false

--- a/docs/workshop-participants.md
+++ b/docs/workshop-participants.md
@@ -1,0 +1,5 @@
+# Workshop Participants
+
+| Name | Date |
+|------|------|
+| Joe Spirk | 2026-03-20 |


### PR DESCRIPTION
## Summary

- Add `docs/workshop-participants.md` tracking workshop attendees (Joe Spirk, 2026-03-20)
- Add `.github/workflows/pr-check.yaml` to enforce conventional commits PR title format

## Related Issues

<!-- No related issue for this workshop exercise -->

## Type of Change

- [x] Documentation update
- [x] CI/CD or tooling change

## Checklist

- [x] I have read the Contributing section in [README.md](../README.md)
- [x] My changes follow the skill structure in [AGENTS.md](../AGENTS.md)
- [x] I have tested my changes with an AI assistant
- [x] I have updated documentation as needed
- [ ] My skill includes all required files (if adding a new skill)

## Testing Notes

- `docs/workshop-participants.md` is a new documentation file — no functional logic to test
- `pr-check.yaml` uses `amannn/action-semantic-pull-request@v5` (widely used action); will be validated on first PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)