### PR TITLE
docs(site): sweep em-dash-sweep ' . ' scars in doc bodies (anchor-aware)

### DIFF
--- a/site/src/content/docs/changelog.md
+++ b/site/src/content/docs/changelog.md
@@ -295,21 +295,21 @@ skills.sh CLI compatibility patch. Unblocks `npx skills add product-on-purpose/p
 
 - Dry-run against live skills CLI (`npx skills add <local path> -l`) added as a de facto pre-release validation. Phase 3 of the distribution plan documents the exact commands. Recommended for any future release that touches SKILL.md frontmatter.
 
-## [2.11.0] . 2026-04-18
+## [2.11.0] - 2026-04-18
 
 Foundation-phase expansion release. Ships 6 new foundation skills (lean canvas + 5-skill meeting lifecycle family), a canonical skill-family contract pattern enforced by CI, 15 thread-aligned library samples, and end-user documentation. First pm-skills release with a cross-cutting skill-family contract. Two rounds of Codex adversarial review before tag.
 
 ### Added
 
 **6 new foundation skills**:
-- **F-26: `foundation-lean-canvas`** (`/lean-canvas`) . one-page business thesis across 9 interlocking blocks with optional HTML visual rendering (content + visual modes; Ash Maurya nine-block layout; 3 thread samples)
-- **F-18: `foundation-meeting-agenda`** (`/meeting-agenda`) . attendee-facing agenda with time-boxed topics, type tags, owners, prep; 10 meeting-type variants; anti-meeting check with synchronous-value requirement
-- **F-25: `foundation-meeting-brief`** (`/meeting-brief`) . user's private strategic prep with stakeholder reads, ranked outcomes, anticipated Q&A; `visibility: private` default
-- **F-27: `foundation-meeting-recap`** (`/meeting-recap`) . topic-segmented post-meeting summary with decisions bold-flagged and actions inline; auto-discovers sibling agenda; ownership reconciliation threshold at 30% unassigned
-- **F-17: `foundation-meeting-synthesize`** (`/meeting-synthesize`) . cross-meeting archaeology surfacing patterns, trajectories, contradictions; format hints (board-prep, onboarding, retro-input, exec-brief)
-- **F-28: `foundation-stakeholder-update`** (`/stakeholder-update`) . async outward comms with 5 channel × 5 audience variants; explicit Shareable update boundary
+- **F-26: `foundation-lean-canvas`** (`/lean-canvas`) - one-page business thesis across 9 interlocking blocks with optional HTML visual rendering (content + visual modes; Ash Maurya nine-block layout; 3 thread samples)
+- **F-18: `foundation-meeting-agenda`** (`/meeting-agenda`) - attendee-facing agenda with time-boxed topics, type tags, owners, prep; 10 meeting-type variants; anti-meeting check with synchronous-value requirement
+- **F-25: `foundation-meeting-brief`** (`/meeting-brief`) - user's private strategic prep with stakeholder reads, ranked outcomes, anticipated Q&A; `visibility: private` default
+- **F-27: `foundation-meeting-recap`** (`/meeting-recap`) - topic-segmented post-meeting summary with decisions bold-flagged and actions inline; auto-discovers sibling agenda; ownership reconciliation threshold at 30% unassigned
+- **F-17: `foundation-meeting-synthesize`** (`/meeting-synthesize`) - cross-meeting archaeology surfacing patterns, trajectories, contradictions; format hints (board-prep, onboarding, retro-input, exec-brief)
+- **F-28: `foundation-stakeholder-update`** (`/stakeholder-update`) - async outward comms with 5 channel × 5 audience variants; explicit Shareable update boundary
 
-**Meeting Skills Family Contract v1.1.0** at `docs/reference/skill-families/meeting-skills-contract.md` . canonical, CI-enforced, shipped after two rounds of adversarial review with errata-within-version.
+**Meeting Skills Family Contract v1.1.0** at `docs/reference/skill-families/meeting-skills-contract.md` - canonical, CI-enforced, shipped after two rounds of adversarial review with errata-within-version.
 
 **New directory pattern** `docs/reference/skill-families/` with landing-page index for future cross-cutting skill-family contracts.
 
@@ -320,13 +320,13 @@ Foundation-phase expansion release. Ships 6 new foundation skills (lean canvas +
 **End-user guide** `docs/guides/using-meeting-skills.md` with 3 mermaid diagrams (family skills graph, go-mode decision flow, chain sequence).
 
 **Release-plan companion docs**:
-- `plan_v2.11.0.md` . release plan with decisions table and deliverables
-- `plan_v2.11_codex-review.md` . Round 1 + Round 2 findings tracker (26 findings total)
-- `plan_v2.11_ci-coverage-analysis.md` . CI gaps and follow-up scripts
-- `plan_v2.11_pre-release-checklist.md` . pre-release quality checklist (Phase 0 Adversarial Review Loop added from v2.11.0 learnings)
-- `plan_v2.11_review-journal.md` . comprehensive narrative of all reviews, findings, resolutions, pattern analysis
+- `plan_v2.11.0.md` - release plan with decisions table and deliverables
+- `plan_v2.11_codex-review.md` - Round 1 + Round 2 findings tracker (26 findings total)
+- `plan_v2.11_ci-coverage-analysis.md` - CI gaps and follow-up scripts
+- `plan_v2.11_pre-release-checklist.md` - pre-release quality checklist (Phase 0 Adversarial Review Loop added from v2.11.0 learnings)
+- `plan_v2.11_review-journal.md` - comprehensive narrative of all reviews, findings, resolutions, pattern analysis
 
-**v2.12.0 backlog** . 7 efforts created for sample-automation loop (F-31 to F-35) + meeting-skills ecosystem continuation (F-29, F-30). Stub at `docs/internal/release-plans/v2.12.0/plan_v2.12.0.md`.
+**v2.12.0 backlog** - 7 efforts created for sample-automation loop (F-31 to F-35) + meeting-skills ecosystem continuation (F-29, F-30). Stub at `docs/internal/release-plans/v2.12.0/plan_v2.12.0.md`.
 
 ### Changed
 
@@ -334,34 +334,34 @@ Foundation-phase expansion release. Ships 6 new foundation skills (lean canvas +
 - **Foundation classification 1 → 7** (adds lean-canvas + 5 meeting skills to persona)
 - **Slash commands 39 → 45** (+6)
 - Current-state count references updated across `README.md`, `CLAUDE.md`, `plugin.json`, `marketplace.json`, `docs/getting-started.md`, `docs/reference/commands.md`, `docs/skills/index.md`, `docs/reference/ecosystem.md`, `docs/reference/project-structure.md`, `docs/guides/mcp-setup.md`, `QUICKSTART.md`, `docs/index.md`, `docs/concepts/agent-skill-anatomy.md`
-- `library/skill-output-samples/README_SAMPLES.md` . count 94 → 120 with 6-category breakdown (canonical, legacy/orbit, persona, lean-canvas, utility-single-thread, meeting-family)
-- `AGENTS.md` . 5 new foundation-meeting-* entries with family-contract note
-- `mkdocs.yml` . Foundation nav expanded to 7 skills + new Reference → Skill Families section + Guides section
-- `.github/workflows/validation.yml` . 2 new enforcing steps for `validate-meeting-skills-family` (bash + powershell)
-- `docs/internal/efforts/F-17-meeting-synthesis.md` and `F-18-meeting-prep.md` . archived to `_NOTES/archived-efforts/` and rewritten with expanded family-aware scope
+- `library/skill-output-samples/README_SAMPLES.md` - count 94 → 120 with 6-category breakdown (canonical, legacy/orbit, persona, lean-canvas, utility-single-thread, meeting-family)
+- `AGENTS.md` - 5 new foundation-meeting-* entries with family-contract note
+- `mkdocs.yml` - Foundation nav expanded to 7 skills + new Reference → Skill Families section + Guides section
+- `.github/workflows/validation.yml` - 2 new enforcing steps for `validate-meeting-skills-family` (bash + powershell)
+- `docs/internal/efforts/F-17-meeting-synthesis.md` and `F-18-meeting-prep.md` - archived to `_NOTES/archived-efforts/` and rewritten with expanded family-aware scope
 
 ### Infrastructure / process
 
 - Two rounds of Codex adversarial review (`codex:codex-rescue` subagent) documented in review journal; 26 findings total, 24 resolved same-session
-- Pre-release checklist now starts with Phase 0 Adversarial Review Loop . re-run Codex after each resolution pass until findings stabilize below IMPORTANT severity
+- Pre-release checklist now starts with Phase 0 Adversarial Review Loop - re-run Codex after each resolution pass until findings stabilize below IMPORTANT severity
 - First post-v1.0.0 contract version bump with errata-within-version documented in change log
 
 ### Not shipped in v2.11.0 (deferred)
 
-- R1-I8 IMPORTANT: utility-pm-skill-validate per-skill field enforcement . scoped into F-31 for v2.12.0
-- Retroactive sample generation for existing skills that lack them . post-v2.12.0 candidate
+- R1-I8 IMPORTANT: utility-pm-skill-validate per-skill field enforcement - scoped into F-31 for v2.12.0
+- Retroactive sample generation for existing skills that lack them - post-v2.12.0 candidate
 - MCP server unfreeze criteria (frozen per M-22)
 
-## [2.10.2] . 2026-04-14
+## [2.10.2] - 2026-04-14
 
 Maintenance patch: corrects plugin manifest drift and extends the count-consistency CI to prevent it from recurring. No skill behavior changes.
 
 ### Changed
-- `.claude-plugin/plugin.json` and `marketplace.json` . skill count in description corrected from 29 to 32 (reconciled with the 32-skill repo state shipped in v2.10.0)
-- `scripts/check-count-consistency.sh` / `.ps1` / `.md` . extended to scan tracked `.json` files (previously `.md` only), so drift in `plugin.json` and `marketplace.json` is now caught by the same CI that covers markdown. Threshold comparison changed from `>` to `>=` to catch round-number boundary drift. Added exclusions for `.github/.created-issues.json` (tooling state) and `.github/scripts/` (npm manifests).
-- `README.md` . v2.10.x What's New entry corrected from "10 workflows" to "9 workflows" (no new workflow shipped in v2.10.x; the repo has been at 9 workflows since v2.9.0)
+- `.claude-plugin/plugin.json` and `marketplace.json` - skill count in description corrected from 29 to 32 (reconciled with the 32-skill repo state shipped in v2.10.0)
+- `scripts/check-count-consistency.sh` / `.ps1` / `.md` - extended to scan tracked `.json` files (previously `.md` only), so drift in `plugin.json` and `marketplace.json` is now caught by the same CI that covers markdown. Threshold comparison changed from `>` to `>=` to catch round-number boundary drift. Added exclusions for `.github/.created-issues.json` (tooling state) and `.github/scripts/` (npm manifests).
+- `README.md` - v2.10.x What's New entry corrected from "10 workflows" to "9 workflows" (no new workflow shipped in v2.10.x; the repo has been at 9 workflows since v2.9.0)
 
-## [2.10.1] . 2026-04-13
+## [2.10.1] - 2026-04-13
 
 Documentation and tooling polish following v2.10.0. No skill behavior changes.
 
@@ -370,26 +370,26 @@ Documentation and tooling polish following v2.10.0. No skill behavior changes.
 - Generated `docs/skills/` pages for F-16, F-19, F-24
 
 ### Changed
-- `scripts/generate-skill-pages.py` . skill/command/workflow counts now computed dynamically instead of hardcoded, preventing the stale-count drift that previously required manual sweeps
+- `scripts/generate-skill-pages.py` - skill/command/workflow counts now computed dynamically instead of hardcoded, preventing the stale-count drift that previously required manual sweeps
 - Backlog updated to reflect v2.10.0 shipped state
 
 ### Removed
 - F-25 effort brief (scope moved to a separate agent-config-toolkit initiative)
 
-## [2.10.0] . 2026-04-11
+## [2.10.0] - 2026-04-11
 
 > **Note:** F-16 (mermaid-diagrams) and F-19 (slideshow-creator) content has
 > been available since v2.9.1 but is formally released and documented with
 > v2.10.0 as the utility skill expansion release.
 
 ### Added
-- **F-16: `utility-mermaid-diagrams`** . new utility skill teaching PMs to create syntactically valid mermaid diagrams. 15 diagram types with dual-lens navigation (type catalog + PM use-case guide), dedicated syntax validity reference, planning worksheet, and worked examples. 2,656 lines across 7 files.
-- **F-19: `utility-slideshow-creator`** . new utility skill for generating professional presentations from JSON deck specifications. 18 slide types with dark/light variants, content-to-layout decision logic, calibrated character limits, Google Slides compatibility. Ships with a generic professional theme. 766 lines across 7 files.
-- **F-24: `utility-update-pm-skills`** . new utility skill for checking, previewing, and applying pm-skills updates. Three modes: `--status` (quick version check), `--report-only` (preview without writing files), default (full update with confirmation). Includes validated-before-copy safety, optional backup, value-delta reports, post-update smoke test, 13-item quality checklist, FAQ, and degraded mode for no-network environments.
+- **F-16: `utility-mermaid-diagrams`** - new utility skill teaching PMs to create syntactically valid mermaid diagrams. 15 diagram types with dual-lens navigation (type catalog + PM use-case guide), dedicated syntax validity reference, planning worksheet, and worked examples. 2,656 lines across 7 files.
+- **F-19: `utility-slideshow-creator`** - new utility skill for generating professional presentations from JSON deck specifications. 18 slide types with dark/light variants, content-to-layout decision logic, calibrated character limits, Google Slides compatibility. Ships with a generic professional theme. 766 lines across 7 files.
+- **F-24: `utility-update-pm-skills`** - new utility skill for checking, previewing, and applying pm-skills updates. Three modes: `--status` (quick version check), `--report-only` (preview without writing files), default (full update with confirmation). Includes validated-before-copy safety, optional backup, value-delta reports, post-update smoke test, 13-item quality checklist, FAQ, and degraded mode for no-network environments.
 - `/mermaid-diagrams` slash command
 - `/slideshow-creator` slash command
 - `/update-pm-skills` slash command with `--status` and `--report-only` flags
-- `docs/guides/updating-pm-skills.md` . user-facing guide for the update skill
+- `docs/guides/updating-pm-skills.md` - user-facing guide for the update skill
 - `_pm-skills/` local state directory convention (gitignored) for update reports and backups
 - 7 new sample outputs in `library/skill-output-samples/` for deliver-acceptance-criteria and all 6 utility skills (storevine thread). Sample library: 84 → 91, now covering all 32 skills.
 - Generated `docs/skills/` pages for all 3 new utility skills
@@ -397,58 +397,58 @@ Documentation and tooling polish following v2.10.0. No skill behavior changes.
 ### Changed
 - Repo now ships 32 skills (25 phase + 1 foundation + 6 utility), 39 command docs, and 10 workflows
 - Comprehensive docs count sweep across 20+ files
-- MCP server decoupled from pm-skills release cycle (M-22) . frozen, no longer a release prerequisite
+- MCP server decoupled from pm-skills release cycle (M-22) - frozen, no longer a release prerequisite
 - Codex cross-LLM review completed for release plan and F-24 feature design (1 Blocker, 12 Major, 11 Minor resolved)
 
-## [2.9.1] . 2026-04-10
+## [2.9.1] - 2026-04-10
 
 ### Added
-- **D-05: Workflows guide** . dedicated `docs/guides/using-workflows.md` with decision tree (mermaid), comparison matrix for all 9 workflows, invocation guide, and customization patterns. Replaces the brief workflow section previously in `using-skills.md`.
-- **M-20: Documentation count consistency CI** . 3 new validation script pairs:
-  - `check-workflow-coverage` . verifies every workflow has matching docs page, AGENTS.md entry, and mkdocs nav entry
-  - `check-count-consistency` . detects stale hardcoded skill/command/workflow counts in documentation
-  - `check-generated-freshness` . verifies generated workflow pages match sources
-- `validate-version-consistency` . hard-fail CI check ensuring `plugin.json` and `marketplace.json` versions match
-- `validate-gitignore-pm-skills` . advisory CI check for `_pm-skills/` in `.gitignore`
-- `validate-script-docs` . advisory CI check ensuring every script pair has companion `.md` documentation
+- **D-05: Workflows guide** - dedicated `docs/guides/using-workflows.md` with decision tree (mermaid), comparison matrix for all 9 workflows, invocation guide, and customization patterns. Replaces the brief workflow section previously in `using-skills.md`.
+- **M-20: Documentation count consistency CI** - 3 new validation script pairs:
+  - `check-workflow-coverage` - verifies every workflow has matching docs page, AGENTS.md entry, and mkdocs nav entry
+  - `check-count-consistency` - detects stale hardcoded skill/command/workflow counts in documentation
+  - `check-generated-freshness` - verifies generated workflow pages match sources
+- `validate-version-consistency` - hard-fail CI check ensuring `plugin.json` and `marketplace.json` versions match
+- `validate-gitignore-pm-skills` - advisory CI check for `_pm-skills/` in `.gitignore`
+- `validate-script-docs` - advisory CI check ensuring every script pair has companion `.md` documentation
 - Companion `.md` documentation for all new scripts and 2 previously undocumented scripts (`check-context-currency`, `check-stale-bundle-refs`)
 - `_pm-skills/` added to `.gitignore` (local state directory for update reports and backups)
 
 ### Changed
-- `scripts/README_SCRIPTS.md` . expanded from 8 to 16 script entries with updated "When to use what" guide
-- `.github/workflows/validation.yml` . added 6 new CI checks (1 hard-fail, 5 advisory)
-- `docs/guides/using-skills.md` . trimmed workflow section to overview + link to new dedicated guide
-- `docs/workflows/index.md` . added link to workflows guide
-- `mkdocs.yml` . added "Using Workflows" nav entry under Guides
+- `scripts/README_SCRIPTS.md` - expanded from 8 to 16 script entries with updated "When to use what" guide
+- `.github/workflows/validation.yml` - added 6 new CI checks (1 hard-fail, 5 advisory)
+- `docs/guides/using-skills.md` - trimmed workflow section to overview + link to new dedicated guide
+- `docs/workflows/index.md` - added link to workflows guide
+- `mkdocs.yml` - added "Using Workflows" nav entry under Guides
 - Fixed `marketplace.json` version 2.8.2 → 2.9.0 (was out of sync with `plugin.json`)
 
-## [2.9.0] . 2026-04-06
+## [2.9.0] - 2026-04-06
 
 ### Added
 - 6 new workflows: Customer Discovery, Sprint Planning, Product Strategy, Post-Launch Learning, Stakeholder Alignment, Technical Discovery
 - 7 `/workflow-*` slash commands (1 renamed from M-19 + 6 new)
-- `scripts/generate-workflow-pages.py` . generates docs/workflows/ from source _workflows/
+- `scripts/generate-workflow-pages.py` - generates docs/workflows/ from source _workflows/
 
 ### Changed
 - **BREAKING:** Renamed `_bundles/` → `_workflows/` and `docs/bundles/` → `docs/workflows/`
-- **BREAKING:** Removed `/kickoff` command . replaced by `/workflow-feature-kickoff`
+- **BREAKING:** Removed `/kickoff` command - replaced by `/workflow-feature-kickoff`
 - Renamed "Workflow Bundles" → "Workflows" across all documentation
 - Added URL redirects for old `/bundles/*` doc site paths
 
 ## [2.8.2] - 2026-04-04
 
 ### Added
-- **Skill versioning concepts page** . `docs/concepts/versioning.md`: public-facing guide to skill SemVer, HISTORY.md, skills-manifest.yaml, tie-breaker rule, and lifecycle tool integration.
-- **git-revision-date-localized plugin** . shows "last updated" and "created" dates on every page (enabled in CI).
-- **Custom CSS** . `docs/stylesheets/extra.css` for card grid, tag badge, and admonition styling.
-- **Theme overrides directory** . `overrides/` for future MkDocs Material customization.
-- **F-12 effort brief** . skill quality convergence draft (first real-world use of lifecycle tools at scale).
+- **Skill versioning concepts page** - `docs/concepts/versioning.md`: public-facing guide to skill SemVer, HISTORY.md, skills-manifest.yaml, tie-breaker rule, and lifecycle tool integration.
+- **git-revision-date-localized plugin** - shows "last updated" and "created" dates on every page (enabled in CI).
+- **Custom CSS** - `docs/stylesheets/extra.css` for card grid, tag badge, and admonition styling.
+- **Theme overrides directory** - `overrides/` for future MkDocs Material customization.
+- **F-12 effort brief** - skill quality convergence draft (first real-world use of lifecycle tools at scale).
 
 ### Changed
-- `requirements-docs.txt` . added `mkdocs-git-revision-date-localized-plugin`.
-- `mkdocs.yml` . added git-revision-date, custom_dir, extra_css, versioning page in nav.
-- `docs/reference/categories.md` . fixed stale coordination skill count (5→7) and total (27→29).
-- `marketplace.json` . updated to v2.8.1 / 29 skills.
+- `requirements-docs.txt` - added `mkdocs-git-revision-date-localized-plugin`.
+- `mkdocs.yml` - added git-revision-date, custom_dir, extra_css, versioning page in nav.
+- `docs/reference/categories.md` - fixed stale coordination skill count (5→7) and total (27→29).
+- `marketplace.json` - updated to v2.8.1 / 29 skills.
 
 ### Release Notes
 - Documentation-only release. No skill or command behavior changes.
@@ -457,27 +457,27 @@ Documentation and tooling polish following v2.10.0. No skill behavior changes.
 ## [2.8.1] - 2026-04-04 ([release notes](releases/Release_v2.8.1.md))
 
 ### Added
-- **Documentation site** at [product-on-purpose.github.io/pm-skills](https://product-on-purpose.github.io/pm-skills/) . MkDocs Material with tab navigation, dark mode, search, and mermaid diagram rendering.
-- **"Follow the Product" showcase** . 3 interactive narrative journeys (Storevine B2B, Brainshelf Consumer, Workbench Enterprise) with 84 real sample outputs from the sample library, including prompts and full artifacts.
-- **Skill finder** . interactive decision tree and artifact table for choosing the right skill.
-- **Recipes** . 7 end-to-end workflows (Pitch a Feature, Run an Experiment, Launch a Feature, Discover and Frame, Define the Opportunity, Sprint Retro, Full Lifecycle) with mermaid flow diagrams.
-- **Skill comparisons** . 6 side-by-side comparisons for commonly confused skill pairs (PRD vs Solution Brief, Hypothesis vs Problem Statement, etc.).
-- **Prompt gallery** . curated real prompts in 3 styles (organized, casual, enterprise) from the sample library.
-- **Per-skill real-world examples** . 3 collapsible sample outputs (one per narrative thread) embedded on 25 skill pages.
-- **Quick-try snippets** . copy-pasteable slash command at the top of every skill page.
-- **Phase flow diagrams** . mermaid diagrams on all 6 phase index pages showing how skills connect.
-- **Tags plugin** . browse skills by phase and category tags.
-- **Social cards** . OpenGraph preview cards for link sharing (enabled in CI).
-- **Generation scripts** . `scripts/generate-skill-pages.py` (29 skill pages + indexes + commands ref) and `scripts/generate-showcase.py` (3 showcase journeys from sample library).
-- **Deploy workflow** . `.github/workflows/deploy-docs.yml` auto-deploys on push to main.
-- **MkDocs config guide** . `docs/internal/mkdocs/mkdocs-config.md` for maintainers.
-- **MCP setup guide** . `docs/guides/mcp-setup.md` for users: install, configure, and use pm-skills-mcp across Claude Desktop, Cursor, Claude Code, and VS Code.
+- **Documentation site** at [product-on-purpose.github.io/pm-skills](https://product-on-purpose.github.io/pm-skills/) - MkDocs Material with tab navigation, dark mode, search, and mermaid diagram rendering.
+- **"Follow the Product" showcase** - 3 interactive narrative journeys (Storevine B2B, Brainshelf Consumer, Workbench Enterprise) with 84 real sample outputs from the sample library, including prompts and full artifacts.
+- **Skill finder** - interactive decision tree and artifact table for choosing the right skill.
+- **Recipes** - 7 end-to-end workflows (Pitch a Feature, Run an Experiment, Launch a Feature, Discover and Frame, Define the Opportunity, Sprint Retro, Full Lifecycle) with mermaid flow diagrams.
+- **Skill comparisons** - 6 side-by-side comparisons for commonly confused skill pairs (PRD vs Solution Brief, Hypothesis vs Problem Statement, etc.).
+- **Prompt gallery** - curated real prompts in 3 styles (organized, casual, enterprise) from the sample library.
+- **Per-skill real-world examples** - 3 collapsible sample outputs (one per narrative thread) embedded on 25 skill pages.
+- **Quick-try snippets** - copy-pasteable slash command at the top of every skill page.
+- **Phase flow diagrams** - mermaid diagrams on all 6 phase index pages showing how skills connect.
+- **Tags plugin** - browse skills by phase and category tags.
+- **Social cards** - OpenGraph preview cards for link sharing (enabled in CI).
+- **Generation scripts** - `scripts/generate-skill-pages.py` (29 skill pages + indexes + commands ref) and `scripts/generate-showcase.py` (3 showcase journeys from sample library).
+- **Deploy workflow** - `.github/workflows/deploy-docs.yml` auto-deploys on push to main.
+- **MkDocs config guide** - `docs/internal/mkdocs/mkdocs-config.md` for maintainers.
+- **MCP setup guide** - `docs/guides/mcp-setup.md` for users: install, configure, and use pm-skills-mcp across Claude Desktop, Cursor, Claude Code, and VS Code.
 
 ### Changed
-- **MCP integration guide** . updated tool counts (25→29 skill tools, 42 total), added acceptance-criteria and utility skill tools, updated slash command mapping table, removed stale catalog note, updated version references to v2.8.0.
+- **MCP integration guide** - updated tool counts (25→29 skill tools, 42 total), added acceptance-criteria and utility skill tools, updated slash command mapping table, removed stale catalog note, updated version references to v2.8.0.
 
 ### Release Notes
-- Documentation-only release . no PM skill or slash-command behavior changes.
+- Documentation-only release - no PM skill or slash-command behavior changes.
 - No `pm-skills-mcp` update required.
 - Site is generated from existing content (skills, samples, docs) plus new guide pages.
 - 70+ navigable pages, zero build warnings.
@@ -485,53 +485,53 @@ Documentation and tooling polish following v2.10.0. No skill behavior changes.
 ## [2.8.0] - 2026-04-03 ([release notes](releases/Release_v2.8.0.md))
 
 ### Added
-- **F-10: utility-pm-skill-validate skill** (#121) . second utility skill. Audits existing skills against structural conventions (mirroring CI) and LLM-assessed quality criteria. Produces a pipe-delimited validation report (`Report schema: v1`) with severity-graded findings (FAIL/WARN/INFO) and actionable recommendations with target file paths. Two-tier assessment rebaselined against shipped library conventions. Includes SKILL.md, TEMPLATE.md (report format), EXAMPLE.md (validated `deliver-prd`), `/pm-skill-validate` command, and AGENTS.md entry. Skill count: 27 → 28.
-- **F-11: utility-pm-skill-iterate skill** (#122) . third utility skill. Applies targeted improvements to existing skills from feedback, validation reports, or convention changes. Unified flow with input normalization, before/after preview, stale-preview guard, version bump class suggestion (don't auto-write), and HISTORY.md creation at second-version trigger point. Includes SKILL.md, TEMPLATE.md (change summary), EXAMPLE.md (iterated `deliver-prd`), `/pm-skill-iterate` command, and AGENTS.md entry. Skill count: 28 → 29.
-- **M-18: CI skill versioning validation** . two new advisory scripts following `.sh` + `.ps1` + `.md` convention: `validate-skill-history` (checks HISTORY.md tracks current frontmatter version) and `validate-skills-manifest` (checks release manifest entries match skill directories). Added to `validation.yml` with `continue-on-error: true`.
-- **D-03: `docs/pm-skill-lifecycle.md`** . public guide explaining the Create → Validate → Iterate lifecycle with workflow patterns (new skill, improve existing, convention change, feedback loop), CI vs validator comparison, and quality standard model.
-- **Governance: `docs/internal/skill-versioning.md`** . SemVer rules for skills, HISTORY.md contract, skills-manifest.yaml format, release checklist, and tie-breaker rule for gray-area version bump classification.
-- `docs/internal/release-plans/v2.7.0/skills-manifest.yaml` . retroactive first use of the skills-manifest convention.
-- `docs/internal/release-plans/v2.8.0/` . release governance with phased execution plan and Codex design review.
+- **F-10: utility-pm-skill-validate skill** (#121) - second utility skill. Audits existing skills against structural conventions (mirroring CI) and LLM-assessed quality criteria. Produces a pipe-delimited validation report (`Report schema: v1`) with severity-graded findings (FAIL/WARN/INFO) and actionable recommendations with target file paths. Two-tier assessment rebaselined against shipped library conventions. Includes SKILL.md, TEMPLATE.md (report format), EXAMPLE.md (validated `deliver-prd`), `/pm-skill-validate` command, and AGENTS.md entry. Skill count: 27 → 28.
+- **F-11: utility-pm-skill-iterate skill** (#122) - third utility skill. Applies targeted improvements to existing skills from feedback, validation reports, or convention changes. Unified flow with input normalization, before/after preview, stale-preview guard, version bump class suggestion (don't auto-write), and HISTORY.md creation at second-version trigger point. Includes SKILL.md, TEMPLATE.md (change summary), EXAMPLE.md (iterated `deliver-prd`), `/pm-skill-iterate` command, and AGENTS.md entry. Skill count: 28 → 29.
+- **M-18: CI skill versioning validation** - two new advisory scripts following `.sh` + `.ps1` + `.md` convention: `validate-skill-history` (checks HISTORY.md tracks current frontmatter version) and `validate-skills-manifest` (checks release manifest entries match skill directories). Added to `validation.yml` with `continue-on-error: true`.
+- **D-03: `docs/pm-skill-lifecycle.md`** - public guide explaining the Create → Validate → Iterate lifecycle with workflow patterns (new skill, improve existing, convention change, feedback loop), CI vs validator comparison, and quality standard model.
+- **Governance: `docs/internal/skill-versioning.md`** - SemVer rules for skills, HISTORY.md contract, skills-manifest.yaml format, release checklist, and tie-breaker rule for gray-area version bump classification.
+- `docs/internal/release-plans/v2.7.0/skills-manifest.yaml` - retroactive first use of the skills-manifest convention.
+- `docs/internal/release-plans/v2.8.0/` - release governance with phased execution plan and Codex design review.
 
 ### Changed
-- **D-04: public docs refresh for v2.8.0** . updated skill counts (29), command counts (30), utility skill breakdown (3), Skill Lifecycle Tools section in README and QUICKSTART, command table, AGENTS.md entries, AGENTS/claude/CONTEXT.md, `docs/pm-skill-anatomy.md` lifecycle cross-reference, and `scripts/README_SCRIPTS.md` with M-18 script documentation.
+- **D-04: public docs refresh for v2.8.0** - updated skill counts (29), command counts (30), utility skill breakdown (3), Skill Lifecycle Tools section in README and QUICKSTART, command table, AGENTS.md entries, AGENTS/claude/CONTEXT.md, `docs/pm-skill-anatomy.md` lifecycle cross-reference, and `scripts/README_SCRIPTS.md` with M-18 script documentation.
 - `docs/internal/releases/` renamed to `docs/internal/release-plans/` with all internal references updated (34 files).
 - `docs/internal/backlog-canonical.md` updated with v2.8.0 assignments (F-10, F-11, D-03, M-18, D-04).
 
 ### Release Notes
 - Completes the **PM skill lifecycle**: Create (`/pm-skill-builder`, v2.7.0) → Validate (`/pm-skill-validate`) → Iterate (`/pm-skill-iterate`).
-- First release with **skill versioning governance** . skills-manifest.yaml per release, HISTORY.md per skill (opt-in), SemVer tie-breaker rule.
-- First release with **advisory CI for skill versioning** . HISTORY.md and skills-manifest.yaml validators.
+- First release with **skill versioning governance** - skills-manifest.yaml per release, HISTORY.md per skill (opt-in), SemVer tie-breaker rule.
+- First release with **advisory CI for skill versioning** - HISTORY.md and skills-manifest.yaml validators.
 - Repo now contains 29 skills (25 domain + 1 foundation + 3 utility), 30 command docs, and 3 workflow bundles.
 - **MCP note**: `pm-skills-mcp` needs a re-embed to pick up both new skills. `utility-pm-skill-validate` → `pm_pm_skill_validate`. `utility-pm-skill-iterate` → `pm_pm_skill_iterate`.
 
 ## [2.7.0] - 2026-03-22 ([release notes](releases/Release_v2.7.0.md))
 
 ### Added
-- **F-06: deliver-acceptance-criteria skill** (#114) . new Deliver phase skill for Given/When/Then acceptance criteria generation covering happy path, edge cases, error states, and non-functional criteria. Includes SKILL.md, TEMPLATE.md, EXAMPLE.md (e-commerce checkout scenario), `/acceptance-criteria` command, and AGENTS.md entry. Skill count: 25 → 26.
-- **F-05: utility-pm-skill-builder skill** (#113) . first utility-classified skill. Interactive builder that guides contributors from a PM skill idea to a complete Skill Implementation Packet with gap analysis, Why Gate, classification, exemplar-driven drafting, and staging-to-promotion workflow. Includes SKILL.md, TEMPLATE.md, EXAMPLE.md (change-communication scenario), `/pm-skill-builder` command, and AGENTS.md Utility Skills section. Skill count: 26 → 27.
-- **M-12: CI validation enhancement** (#112) . extended linter with description word count (20-100) and TEMPLATE.md header count (≥3) checks; new `validate-agents-md` script for AGENTS.md ↔ skill directory sync; new `check-mcp-impact` advisory script for MCP impact detection. All scripts follow `.sh + .ps1 + .md` convention.
-- **M-16: exclude docs/internal from release ZIP** (#123) . release packagers (`build-release.sh` and `.ps1`) now strip `docs/internal/**` from staged artifacts. Internal governance docs stay tracked in-repo but no longer ship to end users.
-- **D-01: `docs/pm-skill-anatomy.md`** . practical guide to pm-skills skill structure covering directory layout, classification types, frontmatter, Triple Diamond phases, wiring layer, and CI validation. Complements the spec-level `docs/agent-skill-anatomy.md`.
+- **F-06: deliver-acceptance-criteria skill** (#114) - new Deliver phase skill for Given/When/Then acceptance criteria generation covering happy path, edge cases, error states, and non-functional criteria. Includes SKILL.md, TEMPLATE.md, EXAMPLE.md (e-commerce checkout scenario), `/acceptance-criteria` command, and AGENTS.md entry. Skill count: 25 → 26.
+- **F-05: utility-pm-skill-builder skill** (#113) - first utility-classified skill. Interactive builder that guides contributors from a PM skill idea to a complete Skill Implementation Packet with gap analysis, Why Gate, classification, exemplar-driven drafting, and staging-to-promotion workflow. Includes SKILL.md, TEMPLATE.md, EXAMPLE.md (change-communication scenario), `/pm-skill-builder` command, and AGENTS.md Utility Skills section. Skill count: 26 → 27.
+- **M-12: CI validation enhancement** (#112) - extended linter with description word count (20-100) and TEMPLATE.md header count (≥3) checks; new `validate-agents-md` script for AGENTS.md ↔ skill directory sync; new `check-mcp-impact` advisory script for MCP impact detection. All scripts follow `.sh + .ps1 + .md` convention.
+- **M-16: exclude docs/internal from release ZIP** (#123) - release packagers (`build-release.sh` and `.ps1`) now strip `docs/internal/**` from staged artifacts. Internal governance docs stay tracked in-repo but no longer ship to end users.
+- **D-01: `docs/pm-skill-anatomy.md`** - practical guide to pm-skills skill structure covering directory layout, classification types, frontmatter, Triple Diamond phases, wiring layer, and CI validation. Complements the spec-level `docs/agent-skill-anatomy.md`.
 - `_staging/` added to `.gitignore` for pm-skill-builder draft artifacts.
 
 ### Changed
-- **D-02: public docs review for v2.7.0** . updated skill counts (27), command counts (28), M-12 script documentation, domain/foundation/utility classification model, skill template modernization, frontmatter schema with utility example, and `docs/agent-skill-anatomy.md` scope note. Post-F-05 reconciliation patched 3 stale references.
+- **D-02: public docs review for v2.7.0** - updated skill counts (27), command counts (28), M-12 script documentation, domain/foundation/utility classification model, skill template modernization, frontmatter schema with utility example, and `docs/agent-skill-anatomy.md` scope note. Post-F-05 reconciliation patched 3 stale references.
 - Fixed duplicate workflow steps in `validation.yml` (validate-agents-md and check-mcp-impact each ran twice).
 - AGENTS.md gains a `### Utility Skills` section and `/pm-skill-builder` in the Commands table.
 - `docs/internal/backlog-canonical.md` rewritten with Release, Status, and Agent columns.
 - Release governance folders created for v2.2.0, v2.3.0, and v2.7.0 (v2.2.0 and v2.3.0 migrated from legacy locations).
 
 ### Removed
-- `docs/internal/delivery-plan/` . legacy directory removed from tracking.
-- `docs/internal/release-planning/` . legacy directory removed from tracking.
+- `docs/internal/delivery-plan/` - legacy directory removed from tracking.
+- `docs/internal/release-planning/` - legacy directory removed from tracking.
 
 ### Release Notes
-- First release with a **utility** skill classification . `pm-skill-builder` creates new PM skills interactively.
+- First release with a **utility** skill classification - `pm-skill-builder` creates new PM skills interactively.
 - First release with enhanced CI: frontmatter linting, AGENTS.md sync validation, MCP impact detection.
 - Release ZIPs now exclude `docs/internal/**` while preserving all public documentation.
 - Repo now contains 27 skills (25 domain + 1 foundation + 1 utility), 28 command docs, and 3 workflow bundles.
-- **MCP note**: `pm-skills-mcp` needs a re-embed to pick up both new skills. `deliver-acceptance-criteria` → `pm_acceptance_criteria`. `utility-pm-skill-builder` → `pm_pm_skill_builder` (double `pm_` is intentional . preserves skill name, consistent with future `pm_agent_skill_builder`). Update `embed-skills.js` to strip classification prefixes (`foundation-`, `utility-`) alongside phase prefixes.
+- **MCP note**: `pm-skills-mcp` needs a re-embed to pick up both new skills. `deliver-acceptance-criteria` → `pm_acceptance_criteria`. `utility-pm-skill-builder` → `pm_pm_skill_builder` (double `pm_` is intentional - preserves skill name, consistent with future `pm_agent_skill_builder`). Update `embed-skills.js` to strip classification prefixes (`foundation-`, `utility-`) alongside phase prefixes.
 
 ## [2.6.1] - 2026-03-04
 
@@ -760,7 +760,7 @@ Documentation and tooling polish following v2.10.0. No skill behavior changes.
 ## [2.1.0] - 2026-01-27
 
 ### Added
-- **MCP Alignment Milestone** . pm-skills-mcp v2.1.0 now fully aligned with flat structure
+- **MCP Alignment Milestone** - pm-skills-mcp v2.1.0 now fully aligned with flat structure
 - Version alignment table in ecosystem documentation
 
 ### Changed
@@ -813,19 +813,19 @@ Documentation and tooling polish following v2.10.0. No skill behavior changes.
 
 ## [1.2.0] - 2026-01-20
 
-**PM-Skills v1.2.0 . Security & Community Infrastructure**
+**PM-Skills v1.2.0 - Security & Community Infrastructure**
 
 This release adds essential security policies, automated vulnerability scanning, and improved issue/PR templates for community contributions.
 
 ### Added
-- **SECURITY.md** . Security policy with vulnerability reporting guidelines
-- **CodeQL code scanning** . Automated security analysis via GitHub Actions (`.github/workflows/codeql.yml`)
-- **Dependabot configuration** . Automated dependency updates for GitHub Actions and npm (`.github/dependabot.yml`)
-- **Issue templates** . Structured forms for bug reports and feature requests
-  - `bug_report.yml` . Skill-specific bug reporting with environment details
-  - `feature_request.yml` . New skill and enhancement proposals
-  - `config.yml` . Directs questions to Discussions, security issues to policy
-- **Pull request template** . Standardized PR checklist (`.github/PULL_REQUEST_TEMPLATE.md`)
+- **SECURITY.md** - Security policy with vulnerability reporting guidelines
+- **CodeQL code scanning** - Automated security analysis via GitHub Actions (`.github/workflows/codeql.yml`)
+- **Dependabot configuration** - Automated dependency updates for GitHub Actions and npm (`.github/dependabot.yml`)
+- **Issue templates** - Structured forms for bug reports and feature requests
+  - `bug_report.yml` - Skill-specific bug reporting with environment details
+  - `feature_request.yml` - New skill and enhancement proposals
+  - `config.yml` - Directs questions to Discussions, security issues to policy
+- **Pull request template** - Standardized PR checklist (`.github/PULL_REQUEST_TEMPLATE.md`)
 
 ### Changed
 - Issue creation now requires using templates (blank issues disabled)
@@ -837,35 +837,35 @@ This release adds essential security policies, automated vulnerability scanning,
 ## [1.1.1] - 2026-01-20
 
 ### Added
-- **CODE_OF_CONDUCT.md** . Contributor Covenant v2.1 for community guidelines
-- **Attribution headers** . Added HTML comment attribution to all 24 SKILL.md files
+- **CODE_OF_CONDUCT.md** - Contributor Covenant v2.1 for community guidelines
+- **Attribution headers** - Added HTML comment attribution to all 24 SKILL.md files
 - **Open-skills ecosystem submissions**
   - Submitted PR to [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills/pull/62)
   - Submitted to [n-skills marketplace](https://github.com/numman-ali/n-skills/issues/6)
 
 ### Changed
-- **CONTRIBUTING.md** . Updated Code of Conduct section to link to dedicated CODE_OF_CONDUCT.md
-- **README.md** . Updated openskills CLI installation section with accurate guidance
-- **README.md** . Minor formatting cleanup (em dashes, navigation labels, alt text)
+- **CONTRIBUTING.md** - Updated Code of Conduct section to link to dedicated CODE_OF_CONDUCT.md
+- **README.md** - Updated openskills CLI installation section with accurate guidance
+- **README.md** - Minor formatting cleanup (em dashes, navigation labels, alt text)
 
 ### Fixed
-- **openskills#48 resolved** . [numman-ali/openskills#48](https://github.com/numman-ali/openskills/issues/48) fixed in openskills v1.3.1
+- **openskills#48 resolved** - [numman-ali/openskills#48](https://github.com/numman-ali/openskills/issues/48) fixed in openskills v1.3.1
   - Root cause: hardcoded `/` path separator failed on Windows
   - Verified: `anthropics/skills` now installs all 17 skills successfully
   - Note: pm-skills uses deeper nesting than openskills auto-discovers; Git clone recommended
 
 ## [1.1.0] - 2026-01-16
 
-**PM-Skills v1.1.0 . Documentation & README Overhaul**
+**PM-Skills v1.1.0 - Documentation & README Overhaul**
 
 This release brings a comprehensive documentation expansion and a major README redesign following open-source best practices. The README now features better navigation, an FAQ section, and improved discoverability.
 
 ### Added
 - **Comprehensive Documentation Expansion**
-  - `docs/getting-started.md` . Detailed setup guide covering 5 installation methods
-  - `docs/guides/using-skills.md` . Beginner to advanced usage guide with SPICE context framework, skill chaining, and 7 power-user patterns
-  - `docs/guides/authoring-pm-skills.md` . Complete guide for creating and submitting new skills
-  - `docs/frameworks/triple-diamond-delivery-process.md` . Triple Diamond methodology documentation
+  - `docs/getting-started.md` - Detailed setup guide covering 5 installation methods
+  - `docs/guides/using-skills.md` - Beginner to advanced usage guide with SPICE context framework, skill chaining, and 7 power-user patterns
+  - `docs/guides/authoring-pm-skills.md` - Complete guide for creating and submitting new skills
+  - `docs/frameworks/triple-diamond-delivery-process.md` - Triple Diamond methodology documentation
 - **README Major Enhancements**
   - Collapsible Table of Contents for easier navigation
   - FAQ section with 7 expandable Q&A items covering common questions
@@ -887,18 +887,18 @@ This release brings a comprehensive documentation expansion and a major README r
   - Documented openskills CLI compatibility testing
   - Filed [openskills#48](https://github.com/numman-ali/openskills/issues/48) for nested path bug
 - **GitHub Release Workflow**
-  - `.github/workflows/release.yml` . Automated ZIP creation on tag push
+  - `.github/workflows/release.yml` - Automated ZIP creation on tag push
   - Creates two artifacts: full package + Claude.ai bundle
-- **CLAUDE.md** . Agent instructions with documentation rules
+- **CLAUDE.md** - Agent instructions with documentation rules
 
 ### Changed
 - **Documentation Reference Files Significantly Expanded**
-  - `docs/reference/categories.md` . Expanded from 54 to 420+ lines with diagrams, workflows, and framework mappings
-  - `docs/reference/frontmatter-schema.yaml` . Expanded from 91 to 600 lines with validation rules, examples, and best practices
+  - `docs/reference/categories.md` - Expanded from 54 to 420+ lines with diagrams, workflows, and framework mappings
+  - `docs/reference/frontmatter-schema.yaml` - Expanded from 91 to 600 lines with validation rules, examples, and best practices
 - **New `/docs` Taxonomy Structure**
-  - `docs/reference/` . Technical specifications (categories, schema)
-  - `docs/guides/` . How-to guides (using-skills, authoring-pm-skills)
-  - `docs/frameworks/` . Methodology documentation (triple-diamond)
+  - `docs/reference/` - Technical specifications (categories, schema)
+  - `docs/guides/` - How-to guides (using-skills, authoring-pm-skills)
+  - `docs/frameworks/` - Methodology documentation (triple-diamond)
 - Renamed `_docs/` → `docs/` and `_templates/` → `templates/` for standard conventions
 - README.md restructured following best-practices from Best-README-Template and amazing-github-template
 - Updated README.md Quick Start with 4 installation options (Git clone recommended)
@@ -906,32 +906,32 @@ This release brings a comprehensive documentation expansion and a major README r
 - Version badge updated to 1.1.0
 
 ### Fixed
-- Discovered and documented [openskills#48](https://github.com/numman-ali/openskills/issues/48) . nested directory structure bug affecting pm-skills and anthropics/skills
+- Discovered and documented [openskills#48](https://github.com/numman-ali/openskills/issues/48) - nested directory structure bug affecting pm-skills and anthropics/skills
 
 ## [1.0.1] - 2026-01-15
 
 ### Added
-- **All 24 Slash Commands Complete** . Every skill now has a corresponding command
-  - `/competitive-analysis` . Discover phase
-  - `/interview-synthesis` . Discover phase
-  - `/stakeholder-summary` . Discover phase
-  - `/jtbd-canvas` . Define phase
-  - `/opportunity-tree` . Define phase
-  - `/adr` . Develop phase
-  - `/design-rationale` . Develop phase
-  - `/solution-brief` . Develop phase
-  - `/spike-summary` . Develop phase
-  - `/edge-cases` . Deliver phase
-  - `/launch-checklist` . Deliver phase
-  - `/release-notes` . Deliver phase
-  - `/dashboard-requirements` . Measure phase
-  - `/experiment-design` . Measure phase
-  - `/experiment-results` . Measure phase
-  - `/instrumentation-spec` . Measure phase
-  - `/lessons-log` . Iterate phase
-  - `/pivot-decision` . Iterate phase
-  - `/refinement-notes` . Iterate phase
-  - `/retrospective` . Iterate phase
+- **All 24 Slash Commands Complete** - Every skill now has a corresponding command
+  - `/competitive-analysis` - Discover phase
+  - `/interview-synthesis` - Discover phase
+  - `/stakeholder-summary` - Discover phase
+  - `/jtbd-canvas` - Define phase
+  - `/opportunity-tree` - Define phase
+  - `/adr` - Develop phase
+  - `/design-rationale` - Develop phase
+  - `/solution-brief` - Develop phase
+  - `/spike-summary` - Develop phase
+  - `/edge-cases` - Deliver phase
+  - `/launch-checklist` - Deliver phase
+  - `/release-notes` - Deliver phase
+  - `/dashboard-requirements` - Measure phase
+  - `/experiment-design` - Measure phase
+  - `/experiment-results` - Measure phase
+  - `/instrumentation-spec` - Measure phase
+  - `/lessons-log` - Iterate phase
+  - `/pivot-decision` - Iterate phase
+  - `/refinement-notes` - Iterate phase
+  - `/retrospective` - Iterate phase
 - GitHub issues #43-62 created and closed for slash command tracking
 
 ### Changed
@@ -941,41 +941,41 @@ This release brings a comprehensive documentation expansion and a major README r
 
 ## [1.0.0] - 2026-01-14
 
-**PM-Skills v1.0.0 . Complete Triple Diamond coverage is here!**
+**PM-Skills v1.0.0 - Complete Triple Diamond coverage is here!**
 
 This release marks the completion of all 24 PM skills across the entire product development lifecycle. From discovery to iteration, PM-Skills now provides comprehensive coverage for product managers using AI assistants.
 
 ### Added
-- **Phase 3 Complete: P2 Skills (11 skills) . All 24 skills now implemented!**
-  - `competitive-analysis` skill . Discover phase (`skills/discover-competitive-analysis/`)
-  - `stakeholder-summary` skill . Discover phase (`skills/discover-stakeholder-summary/`)
-  - `opportunity-tree` skill . Define phase (`skills/define-opportunity-tree/`)
-  - `jtbd-canvas` skill . Define phase (`skills/define-jtbd-canvas/`)
-  - `design-rationale` skill . Develop phase (`skills/develop-design-rationale/`)
-  - `dashboard-requirements` skill . Measure phase (`skills/measure-dashboard-requirements/`)
-  - `experiment-results` skill . Measure phase (`skills/measure-experiment-results/`)
-  - `retrospective` skill . Iterate phase (`skills/iterate-retrospective/`)
-  - `lessons-log` skill . Iterate phase (`skills/iterate-lessons-log/`)
-  - `refinement-notes` skill . Iterate phase (`skills/iterate-refinement-notes/`)
-  - `pivot-decision` skill . Iterate phase (`skills/iterate-pivot-decision/`)
+- **Phase 3 Complete: P2 Skills (11 skills) - All 24 skills now implemented!**
+  - `competitive-analysis` skill - Discover phase (`skills/discover-competitive-analysis/`)
+  - `stakeholder-summary` skill - Discover phase (`skills/discover-stakeholder-summary/`)
+  - `opportunity-tree` skill - Define phase (`skills/define-opportunity-tree/`)
+  - `jtbd-canvas` skill - Define phase (`skills/define-jtbd-canvas/`)
+  - `design-rationale` skill - Develop phase (`skills/develop-design-rationale/`)
+  - `dashboard-requirements` skill - Measure phase (`skills/measure-dashboard-requirements/`)
+  - `experiment-results` skill - Measure phase (`skills/measure-experiment-results/`)
+  - `retrospective` skill - Iterate phase (`skills/iterate-retrospective/`)
+  - `lessons-log` skill - Iterate phase (`skills/iterate-lessons-log/`)
+  - `refinement-notes` skill - Iterate phase (`skills/iterate-refinement-notes/`)
+  - `pivot-decision` skill - Iterate phase (`skills/iterate-pivot-decision/`)
 - Each skill includes SKILL.md, references/TEMPLATE.md, and references/EXAMPLE.md
 - GitHub labels: `phase-3`, `P2`
 - GitHub issues #26-36 for skill tracking
 - **Phase 3 Infrastructure: Workflow Bundles**
-  - `_bundles/triple-diamond.md` . Complete product development cycle guide
-  - `_bundles/lean-startup.md` . Build-Measure-Learn rapid iteration guide
-  - `_bundles/feature-kickoff.md` . Quick-start workflow for feature development
+  - `_bundles/triple-diamond.md` - Complete product development cycle guide
+  - `_bundles/lean-startup.md` - Build-Measure-Learn rapid iteration guide
+  - `_bundles/feature-kickoff.md` - Quick-start workflow for feature development
 - **Phase 3 Infrastructure: Slash Commands**
-  - `commands/prd.md` . Create Product Requirements Document
-  - `commands/problem-statement.md` . Create problem statement
-  - `commands/hypothesis.md` . Define testable hypothesis
-  - `commands/user-stories.md` . Generate user stories
-  - `commands/kickoff.md` . Run Feature Kickoff workflow
+  - `commands/prd.md` - Create Product Requirements Document
+  - `commands/problem-statement.md` - Create problem statement
+  - `commands/hypothesis.md` - Define testable hypothesis
+  - `commands/user-stories.md` - Generate user stories
+  - `commands/kickoff.md` - Run Feature Kickoff workflow
 - **Phase 3 Infrastructure: Agent Discovery**
-  - `AGENTS.md` . Universal agent discovery file listing all 24 skills
+  - `AGENTS.md` - Universal agent discovery file listing all 24 skills
 - **Phase 3 Infrastructure: GitHub Actions**
-  - `.github/workflows/sync-agents-md.yml` . Auto-sync AGENTS.md on skill changes
-  - `.github/workflows/release-zips.yml` . Package skills as ZIPs on release
+  - `.github/workflows/sync-agents-md.yml` - Auto-sync AGENTS.md on skill changes
+  - `.github/workflows/release-zips.yml` - Package skills as ZIPs on release
 
 ### Changed
 - Updated README.md Skills Inventory badge to 24/24 (complete)
@@ -987,14 +987,14 @@ This release marks the completion of all 24 PM skills across the entire product 
 
 ### Added
 - **Phase 2 Complete: P1 Skills (8 skills)**
-  - `interview-synthesis` skill . Discover phase (`skills/discover-interview-synthesis/`)
-  - `solution-brief` skill . Develop phase (`skills/develop-solution-brief/`)
-  - `spike-summary` skill . Develop phase (`skills/develop-spike-summary/`)
-  - `adr` skill . Develop phase (`skills/develop-adr/`)
-  - `edge-cases` skill . Deliver phase (`skills/deliver-edge-cases/`)
-  - `release-notes` skill . Deliver phase (`skills/deliver-release-notes/`)
-  - `experiment-design` skill . Measure phase (`skills/measure-experiment-design/`)
-  - `instrumentation-spec` skill . Measure phase (`skills/measure-instrumentation-spec/`)
+  - `interview-synthesis` skill - Discover phase (`skills/discover-interview-synthesis/`)
+  - `solution-brief` skill - Develop phase (`skills/develop-solution-brief/`)
+  - `spike-summary` skill - Develop phase (`skills/develop-spike-summary/`)
+  - `adr` skill - Develop phase (`skills/develop-adr/`)
+  - `edge-cases` skill - Deliver phase (`skills/deliver-edge-cases/`)
+  - `release-notes` skill - Deliver phase (`skills/deliver-release-notes/`)
+  - `experiment-design` skill - Measure phase (`skills/measure-experiment-design/`)
+  - `instrumentation-spec` skill - Measure phase (`skills/measure-instrumentation-spec/`)
 - Each skill includes SKILL.md, references/TEMPLATE.md, and references/EXAMPLE.md
 - GitHub labels: `phase-2`, `P1`
 - GitHub milestone: v0.3.0 - P1 Skills
@@ -1010,11 +1010,11 @@ This release marks the completion of all 24 PM skills across the entire product 
 
 ### Added
 - **Phase 1 Complete: P0 Core Skills**
-  - `problem-statement` skill . Define phase (`skills/define-problem-statement/`)
-  - `hypothesis` skill . Define phase (`skills/define-hypothesis/`)
-  - `prd` skill . Deliver phase (`skills/deliver-prd/`)
-  - `user-stories` skill . Deliver phase (`skills/deliver-user-stories/`)
-  - `launch-checklist` skill . Deliver phase (`skills/deliver-launch-checklist/`)
+  - `problem-statement` skill - Define phase (`skills/define-problem-statement/`)
+  - `hypothesis` skill - Define phase (`skills/define-hypothesis/`)
+  - `prd` skill - Deliver phase (`skills/deliver-prd/`)
+  - `user-stories` skill - Deliver phase (`skills/deliver-user-stories/`)
+  - `launch-checklist` skill - Deliver phase (`skills/deliver-launch-checklist/`)
 - Each skill includes SKILL.md, references/TEMPLATE.md, and references/EXAMPLE.md
 - GitHub labels: `skill`, `phase-1`, `P0`
 - GitHub milestone: v0.2.0 - P0 Core Skills
@@ -1033,13 +1033,13 @@ This release marks the completion of all 24 PM skills across the entire product 
 - CHANGELOG.md following Keep a Changelog format
 - .gitignore with standard exclusions
 - AGENTS/claude-opus-4.5/ folder for AI session continuity
-  - CONTEXT.md . Project state tracking
-  - TODO.md . Task management
-  - DECISIONS.md . Technical decision log
-  - SESSION-LOG/ . Session documentation
+  - CONTEXT.md - Project state tracking
+  - TODO.md - Task management
+  - DECISIONS.md - Technical decision log
+  - SESSION-LOG/ - Session documentation
 - PLANNING/ folder convention for collaboration artifacts (reviews, drafts, analysis)
-- plan-v1-review.md . Comprehensive review of implementation plan
-- v0.1 tag . Plan review milestone
+- plan-v1-review.md - Comprehensive review of implementation plan
+- v0.1 tag - Plan review milestone
 - 9 GitHub issues for plan-v1.md improvement opportunities
 - **Phase 0 Foundation Complete:**
   - CONTRIBUTING.md with curated contribution model
@@ -1053,7 +1053,7 @@ This release marks the completion of all 24 PM skills across the entire product 
 - Updated CONTEXT.md status from "Foundation complete" to "Foundation in progress (~40%)"
 - Updated plan-v1.md Progress Tracker with inline status notes
 - Fixed README.md roadmap to reflect accurate Phase 0 status
-- **Phase 0 → 100% complete** . All foundation infrastructure now in place
+- **Phase 0 → 100% complete** - All foundation infrastructure now in place
 - Updated README.md roadmap to show Phase 0 complete
 - Expanded P1/P2 skill guidance in plan-v1.md (Issues #11-29)
 - Updated example dates in templates to use `<YYYY-MM-DD>` placeholder
@@ -1065,4 +1065,4 @@ This release marks the completion of all 24 PM skills across the entire product 
 - Issue #1 conflict with existing files (added "skip if exists" note)
 
 ### Closed
-- All 9 GitHub issues (#1-9) . plan improvements complete
+- All 9 GitHub issues (#1-9) - plan improvements complete

--- a/site/src/content/docs/concepts/agent-skill-anatomy.md
+++ b/site/src/content/docs/concepts/agent-skill-anatomy.md
@@ -11,9 +11,9 @@ A comprehensive reference for understanding the structure, components, and stand
 
 - [Introduction](#introduction)
 - [The Three-Layer Model](#the-three-layer-model)
-  - [Layer 1: SKILL.md . The Instructions](#layer-1-skillmd--the-instructions)
-  - [Layer 2: TEMPLATE.md . The Structure](#layer-2-templatemd--the-structure)
-  - [Layer 3: EXAMPLE.md . The Quality Benchmark](#layer-3-examplemd--the-quality-benchmark)
+  - [Layer 1: SKILL.md - The Instructions](#layer-1-skillmd---the-instructions)
+  - [Layer 2: TEMPLATE.md - The Structure](#layer-2-templatemd---the-structure)
+  - [Layer 3: EXAMPLE.md - The Quality Benchmark](#layer-3-examplemd---the-quality-benchmark)
   - [How the Three Layers Work Together](#how-the-three-layers-work-together)
 - [File System Anatomy](#file-system-anatomy)
   - [Directory Structure](#directory-structure)
@@ -83,7 +83,7 @@ flowchart TD
     Context --> Output
 ```
 
-### Layer 1: SKILL.md . The Instructions
+### Layer 1: SKILL.md - The Instructions
 
 **Purpose**: Provides step-by-step instructions for the AI to follow when creating the artifact.
 
@@ -146,7 +146,7 @@ Use `references/TEMPLATE.md` as the output format.
 See `references/EXAMPLE.md` for a completed example.
 ````
 
-### Layer 2: TEMPLATE.md . The Structure
+### Layer 2: TEMPLATE.md - The Structure
 
 **Purpose**: Defines the exact output structure and format the AI should produce.
 
@@ -194,7 +194,7 @@ status: draft                             # ← Initial status
 - Hierarchical headings show information architecture
 - Frontmatter enables artifact tracking and versioning
 
-### Layer 3: EXAMPLE.md . The Quality Benchmark
+### Layer 3: EXAMPLE.md - The Quality Benchmark
 
 **Purpose**: Demonstrates what a completed, high-quality output looks like in practice.
 
@@ -568,12 +568,12 @@ metadata:
 **Purpose**: List of PM methodologies this skill supports
 
 **Standard identifiers**:
-- `triple-diamond` . 6-phase delivery process (Discover→Iterate)
-- `lean-startup` . Build-Measure-Learn cycle
-- `design-thinking` . Empathize-Define-Ideate-Prototype-Test
-- `scrum` . Sprint-based agile
-- `kanban` . Flow-based agile
-- `safe` . Scaled Agile Framework
+- `triple-diamond` - 6-phase delivery process (Discover→Iterate)
+- `lean-startup` - Build-Measure-Learn cycle
+- `design-thinking` - Empathize-Define-Ideate-Prototype-Test
+- `scrum` - Sprint-based agile
+- `kanban` - Flow-based agile
+- `safe` - Scaled Agile Framework
 
 **Best practice**: Include all applicable frameworks, not just the primary one.
 
@@ -756,7 +756,7 @@ When asked to create a problem statement, follow these steps:
 
 1. **Identify the User Segment**
    Ask who is experiencing this problem. Get specific about the user persona, 
-   role, or segment. Avoid vague descriptions like "users" . instead target 
+   role, or segment. Avoid vague descriptions like "users" - instead target 
    "mobile shoppers completing checkout" or "enterprise admins managing 50+ users."
 
 2. **Understand the Pain Points**
@@ -1069,10 +1069,10 @@ Skills written to the agentskills.io specification work across multiple AI platf
 
 The agentskills.io specification defines:
 
-1. **Standard file structure** . All platforms know where to find SKILL.md, TEMPLATE.md, EXAMPLE.md
-2. **Standard metadata** . Frontmatter schema is universal across platforms
-3. **Standard discovery** . AGENTS.md file format is consistent
-4. **Markdown format** . Platform-agnostic, human-readable
+1. **Standard file structure** - All platforms know where to find SKILL.md, TEMPLATE.md, EXAMPLE.md
+2. **Standard metadata** - Frontmatter schema is universal across platforms
+3. **Standard discovery** - AGENTS.md file format is consistent
+4. **Markdown format** - Platform-agnostic, human-readable
 
 **Example**: The same `prd` skill works identically on:
 
@@ -1198,7 +1198,7 @@ When asked to create a problem statement, follow these steps:
 
 1. **Identify the User Segment**          # ← Actionable step title
    Ask who is experiencing this problem. Get specific about the user persona, 
-   role, or segment. Avoid vague descriptions like "users" . instead target 
+   role, or segment. Avoid vague descriptions like "users" - instead target 
    "mobile shoppers completing checkout" or "enterprise admins managing 50+ users."
                                            # ← Detailed guidance
 
@@ -1312,7 +1312,7 @@ When asked to create a PRD, follow these steps:
 
 4. **Detail Functional Requirements**     # ← Core specification work
    Break down what the system must do. Use user stories or requirement 
-   statements. Each requirement should be testable . someone should be able 
+   statements. Each requirement should be testable - someone should be able 
    to verify if it's met.
 
 5. **Define Scope Boundaries**            # ← Critical for project management
@@ -1526,35 +1526,35 @@ Quick reference for skill authors before submission. For complete guidance, see 
 
 ### Official Specifications
 
-- **[agentskills.io Specification](https://agentskills.io/specification)** . Canonical standard for agent skills
-- **[agentskills/agentskills on GitHub](https://github.com/agentskills/agentskills)** . Reference implementation and examples
+- **[agentskills.io Specification](https://agentskills.io/specification)** - Canonical standard for agent skills
+- **[agentskills/agentskills on GitHub](https://github.com/agentskills/agentskills)** - Reference implementation and examples
 
 ### PM-Skills Documentation
 
-- **[Getting Started Guide](../getting-started/index.md)** . Installation and first steps
-- **[Using Skills Guide](../guides/using-skills.md)** . From beginner to advanced usage
-- **[Creating PM-Skills](../guides/creating-pm-skills.md)** . Complete authoring guide
-- **[Frontmatter Schema](../reference/frontmatter-schema.yaml)** . Field-by-field validation reference
-- **[Category Taxonomy](../reference/categories.md)** . All 7 categories explained
-- **[Contributing Guidelines](../contributing/index.md)** . How to contribute to pm-skills
+- **[Getting Started Guide](../getting-started/index.md)** - Installation and first steps
+- **[Using Skills Guide](../guides/using-skills.md)** - From beginner to advanced usage
+- **[Creating PM-Skills](../guides/creating-pm-skills.md)** - Complete authoring guide
+- **[Frontmatter Schema](../reference/frontmatter-schema.yaml)** - Field-by-field validation reference
+- **[Category Taxonomy](../reference/categories.md)** - All 7 categories explained
+- **[Contributing Guidelines](../contributing/index.md)** - How to contribute to pm-skills
 
 ### Community & Ecosystem
 
-- **[PM-Skills Repository](https://github.com/product-on-purpose/pm-skills)** . Main repository
-- **[Skill Template](https://github.com/product-on-purpose/pm-skills/blob/main/docs/templates/skill-template/SKILL.md)** . Starting point for new skills
-- **[Triple Diamond Framework](triple-diamond-delivery-process.md)** . The organizing methodology
+- **[PM-Skills Repository](https://github.com/product-on-purpose/pm-skills)** - Main repository
+- **[Skill Template](https://github.com/product-on-purpose/pm-skills/blob/main/docs/templates/skill-template/SKILL.md)** - Starting point for new skills
+- **[Triple Diamond Framework](triple-diamond-delivery-process.md)** - The organizing methodology
 
 ### Platform Documentation
 
-- **[VS Code Agent Skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills)** . Using skills in VS Code Copilot
-- **[Cursor Agent Skills](https://cursor.com/docs/context/skills)** . Using skills in Cursor
+- **[VS Code Agent Skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills)** - Using skills in VS Code Copilot
+- **[Cursor Agent Skills](https://cursor.com/docs/context/skills)** - Using skills in Cursor
 
 ### Standards & References
 
-- **[Semantic Versioning](https://semver.org/)** . Version numbering standard
-- **[SPDX Licenses](https://spdx.org/licenses/)** . License identifier list
-- **[Markdown Guide](https://www.markdownguide.org/)** . Markdown syntax reference
-- **[YAML Specification](https://yaml.org/spec/)** . YAML format details
+- **[Semantic Versioning](https://semver.org/)** - Version numbering standard
+- **[SPDX Licenses](https://spdx.org/licenses/)** - License identifier list
+- **[Markdown Guide](https://www.markdownguide.org/)** - Markdown syntax reference
+- **[YAML Specification](https://yaml.org/spec/)** - YAML format details
 
 ---
 
@@ -1610,6 +1610,6 @@ Quick reference for skill authors before submission. For complete guidance, see 
 
 ---
 
-*Part of [PM-Skills](https://github.com/product-on-purpose/pm-skills/blob/main/README.md) . Open source Product Management skills for AI agents*
+*Part of [PM-Skills](https://github.com/product-on-purpose/pm-skills/blob/main/README.md) - Open source Product Management skills for AI agents*
 
 *Built by [Product on Purpose](https://github.com/product-on-purpose) for PMs who ship.*

--- a/site/src/content/docs/concepts/index.md
+++ b/site/src/content/docs/concepts/index.md
@@ -3,7 +3,7 @@ title: Concepts
 description: Understanding how PM skills work, the Triple Diamond framework, and the skill lifecycle.
 ---
 
-Understand the ideas behind PM Skills . what agent skills are, how they're structured, and how they evolve.
+Understand the ideas behind PM Skills - what agent skills are, how they're structured, and how they evolve.
 
 | Topic | Description |
 |-------|-------------|

--- a/site/src/content/docs/concepts/triple-diamond-delivery-process.md
+++ b/site/src/content/docs/concepts/triple-diamond-delivery-process.md
@@ -21,16 +21,16 @@ The Double Diamond's elegance lies in its simplicity: two diamonds representing 
 
 The original four phases are:
 
-1. **Discover** . Understand the issue through research and user engagement
-2. **Define** . Synthesize insights into a clear problem statement
-3. **Develop** . Generate and explore potential solutions
-4. **Deliver** . Test, refine, and implement the chosen solution
+1. **Discover** - Understand the issue through research and user engagement
+2. **Define** - Synthesize insights into a clear problem statement
+3. **Develop** - Generate and explore potential solutions
+4. **Deliver** - Test, refine, and implement the chosen solution
 
 ### Why a Third Diamond?
 
 When Zendesk's product design team set out to document their design process, they turned naturally to the Double Diamond as their starting point. However, rather than adopting it wholesale, they used it as a conversation starter that revealed critical gaps in the model.
 
-The team identified a fundamental limitation: the Double Diamond is too design-centric. As Mike Chen from Zendesk's design team articulated, the model creates an expectation that designs are "completed and handed off for implementation by engineers" . a simplification that doesn't reflect modern product development reality.
+The team identified a fundamental limitation: the Double Diamond is too design-centric. As Mike Chen from Zendesk's design team articulated, the model creates an expectation that designs are "completed and handed off for implementation by engineers" - a simplification that doesn't reflect modern product development reality.
 
 For Zendesk, "Ship" was oversimplified. The journey from validated design concept to commercially available product involves multiple internal milestones, cross-functional coordination, and iterative refinement that the Double Diamond framework doesn't capture.
 
@@ -40,7 +40,7 @@ This realization led to the creation of the Triple Diamond, which adds a third d
 
 ## The Triple Diamond Framework
 
-The Triple Diamond extends the original model by acknowledging that user experience is not solely the designers' responsibility . it's a collaborative effort involving designers, engineers, product managers, QA teams, localization specialists, documentation writers, customer advocacy teams, and go-to-market functions.
+The Triple Diamond extends the original model by acknowledging that user experience is not solely the designers' responsibility - it's a collaborative effort involving designers, engineers, product managers, QA teams, localization specialists, documentation writers, customer advocacy teams, and go-to-market functions.
 
 ### The Three Diamonds at a Glance
 
@@ -107,7 +107,7 @@ Selected concepts are refined and validated with users:
 - **Iteration**: Refining designs based on feedback
 - **Design Specification**: Creating detailed design documentation for implementation
 
-The output is a validated design concept . not a final design, but a solution that has been tested with users and stakeholders and is ready for engineering collaboration.
+The output is a validated design concept - not a final design, but a solution that has been tested with users and stakeholders and is ready for engineering collaboration.
 
 ### Diamond 3: Validation & Delivery
 
@@ -115,7 +115,7 @@ The third diamond represents Zendesk's most significant contribution to design p
 
 #### Key Insight: Design as Concept, Not Handoff
 
-In the Triple Diamond framework, designs that emerge from the second diamond are treated as **concepts that have been validated** . not finished artifacts to be handed off. The team is confident it's the right solution, but it needs further refinement through the engineering and delivery process.
+In the Triple Diamond framework, designs that emerge from the second diamond are treated as **concepts that have been validated** - not finished artifacts to be handed off. The team is confident it's the right solution, but it needs further refinement through the engineering and delivery process.
 
 This reframing has profound implications for how designers and engineers collaborate.
 
@@ -126,7 +126,7 @@ The third diamond marks the start of the iterative Agile development cycle, wher
 - **Engineers investigate technical solutions** while designers continue creating prototypes and conducting usability tests
 - **Research and design happen throughout** the development cycle, not just before it
 - **Uncertainty decreases over time** as the team learns from implementation and user feedback
-- **Flexibility for change decreases progressively** . larger changes happen early, fine-tuning happens later
+- **Flexibility for change decreases progressively** - larger changes happen early, fine-tuning happens later
 
 #### Delivery Milestones
 
@@ -154,7 +154,7 @@ Understanding user perspectives drives meaningful solutions. Teams should put th
 
 ### 2. Cross-Functional Collaboration
 
-User experience is everyone's responsibility. The Triple Diamond explicitly includes engineers, product managers, marketers, support teams, and other stakeholders in the process . not just designers. Different perspectives enrich solutions and identify potential issues early.
+User experience is everyone's responsibility. The Triple Diamond explicitly includes engineers, product managers, marketers, support teams, and other stakeholders in the process - not just designers. Different perspectives enrich solutions and identify potential issues early.
 
 ### 3. Embrace Change Throughout
 
@@ -190,7 +190,7 @@ The visual representation enables clear communication of project progress to sta
 
 ### Process Improvement
 
-The Triple Diamond serves as a starting point for teams to reflect on their own processes. As Zendesk discovered, the value isn't just in the diagram . it's in the conversations it sparks about how work actually gets done.
+The Triple Diamond serves as a starting point for teams to reflect on their own processes. As Zendesk discovered, the value isn't just in the diagram - it's in the conversations it sparks about how work actually gets done.
 
 ---
 
@@ -294,7 +294,7 @@ The Triple Diamond represents a meaningful evolution in how product teams think 
 
 The framework's true value lies not in rigid adherence to its structure, but in the conversations it enables about how work gets done. It provides a common language for designers, engineers, product managers, and go-to-market teams to collaborate effectively across the full product lifecycle.
 
-As you consider adopting the Triple Diamond, remember that it should be adapted to your context. Use it as a starting point, not a prescription. The goal is to create a process that helps your team deliver exceptional user experiences . and the Triple Diamond provides a proven foundation for building that process.
+As you consider adopting the Triple Diamond, remember that it should be adapted to your context. Use it as a starting point, not a prescription. The goal is to create a process that helps your team deliver exceptional user experiences - and the Triple Diamond provides a proven foundation for building that process.
 
 ---
 

--- a/site/src/content/docs/contributing/privacy.md
+++ b/site/src/content/docs/contributing/privacy.md
@@ -11,15 +11,15 @@ PM-Skills **does not collect, transmit, or store any user data**. It is a set of
 
 Specifically:
 
-- **No analytics or telemetry** . no usage data is collected or sent anywhere
-- **No network requests** . the plugin operates entirely offline using local files
-- **No user data storage** . no databases, cookies, local storage, or caching of user content
-- **No authentication** . no accounts, tokens, or credentials are required or processed
-- **No third-party services** . no external APIs are called
+- **No analytics or telemetry** - no usage data is collected or sent anywhere
+- **No network requests** - the plugin operates entirely offline using local files
+- **No user data storage** - no databases, cookies, local storage, or caching of user content
+- **No authentication** - no accounts, tokens, or credentials are required or processed
+- **No third-party services** - no external APIs are called
 
 ## What the Plugin Does
 
-When invoked, an AI agent reads the skill's instruction files (SKILL.md, TEMPLATE.md, EXAMPLE.md) from the local filesystem and uses them to guide artifact generation. All processing happens within the AI agent's session. The plugin provides instructions only . it does not execute code or access external systems.
+When invoked, an AI agent reads the skill's instruction files (SKILL.md, TEMPLATE.md, EXAMPLE.md) from the local filesystem and uses them to guide artifact generation. All processing happens within the AI agent's session. The plugin provides instructions only - it does not execute code or access external systems.
 
 ## Companion MCP Server
 

--- a/site/src/content/docs/guides/creating-pm-skills.md
+++ b/site/src/content/docs/guides/creating-pm-skills.md
@@ -31,11 +31,11 @@ This guide walks you through creating new PM skills for submission to the pm-ski
 
 A good PM skill:
 
-1. **Solves a real problem** . PMs actually need this artifact regularly
-2. **Produces consistent output** . Same quality every time
-3. **Works across contexts** . Useful for different products, teams, industries
-4. **Is well-documented** . Clear instructions, useful template, realistic example
-5. **Integrates with workflows** . Chains naturally with other skills
+1. **Solves a real problem** - PMs actually need this artifact regularly
+2. **Produces consistent output** - Same quality every time
+3. **Works across contexts** - Useful for different products, teams, industries
+4. **Is well-documented** - Clear instructions, useful template, realistic example
+5. **Integrates with workflows** - Chains naturally with other skills
 
 ### The Three Files
 
@@ -163,10 +163,10 @@ Before writing any code, open a "Request a Skill" issue with:
 ### Step 2: Wait for Approval
 
 Maintainers will review your proposal and may:
-- **Approve** . You're cleared to build
-- **Request changes** . Adjust the scope or approach
-- **Suggest alternatives** . An existing skill might work
-- **Decline** . The skill doesn't fit the project
+- **Approve** - You're cleared to build
+- **Request changes** - Adjust the scope or approach
+- **Suggest alternatives** - An existing skill might work
+- **Decline** - The skill doesn't fit the project
 
 ### Step 3: Build the Skill
 
@@ -344,10 +344,10 @@ Valid values: `domain`, `foundation`, `utility`
 
 Before you open a PR, run the repo validators that correspond to your change:
 
-- `./scripts/lint-skills-frontmatter.sh` or `.ps1` . skill frontmatter, description length, template structure
-- `./scripts/validate-commands.sh` or `.ps1` . command file path references
-- `./scripts/validate-agents-md.sh` or `.ps1` . `AGENTS.md` path sync for discoverable skills
-- `./scripts/check-mcp-impact.sh` or `.ps1` . advisory only, but useful when adding or renaming skills
+- `./scripts/lint-skills-frontmatter.sh` or `.ps1` - skill frontmatter, description length, template structure
+- `./scripts/validate-commands.sh` or `.ps1` - command file path references
+- `./scripts/validate-agents-md.sh` or `.ps1` - `AGENTS.md` path sync for discoverable skills
+- `./scripts/check-mcp-impact.sh` or `.ps1` - advisory only, but useful when adding or renaming skills
 
 #### version
 
@@ -410,9 +410,9 @@ List 4-6 specific situations. Be concrete:
 
 Instructions are step-by-step directions the AI follows. Each step should:
 
-1. **Have a clear action title** . What to do
-2. **Explain the purpose** . Why it matters
-3. **Provide guidance** . How to do it well
+1. **Have a clear action title** - What to do
+2. **Explain the purpose** - Why it matters
+3. **Provide guidance** - How to do it well
 
 **Example:**
 ```markdown
@@ -496,10 +496,10 @@ status: draft
 
 ### Template Principles
 
-1. **Use clear section headings** . Match the sections in your instructions
-2. **Include HTML comments** . Guide the AI on what each section needs
-3. **Provide structure hints** . Tables, lists, or prose as appropriate
-4. **Keep it flexible** . Don't over-constrain
+1. **Use clear section headings** - Match the sections in your instructions
+2. **Include HTML comments** - Guide the AI on what each section needs
+3. **Provide structure hints** - Tables, lists, or prose as appropriate
+4. **Keep it flexible** - Don't over-constrain
 
 ### Example: PRD Template (excerpt)
 
@@ -568,10 +568,10 @@ The example shows what a great output looks like. This is crucial for quality ca
 
 ### Example Requirements
 
-1. **Complete** . No placeholders, fully filled out
-2. **Realistic** . Based on a believable scenario
-3. **High quality** . Demonstrates what "good" looks like
-4. **Appropriately detailed** . Not too sparse, not bloated
+1. **Complete** - No placeholders, fully filled out
+2. **Realistic** - Based on a believable scenario
+3. **High quality** - Demonstrates what "good" looks like
+4. **Appropriately detailed** - Not too sparse, not bloated
 
 ### Example Structure
 
@@ -602,10 +602,10 @@ report spending 2+ hours per week on this manual work...
 
 Pick a scenario that is:
 
-- **Relatable** . Most PMs understand it
-- **Representative** . Shows typical complexity
-- **Complete** . Has enough depth to fill all sections
-- **Generic** . Not specific to one industry or company
+- **Relatable** - Most PMs understand it
+- **Representative** - Shows typical complexity
+- **Complete** - Has enough depth to fill all sections
+- **Generic** - Not specific to one industry or company
 
 **Good scenarios:**
 - E-commerce: Search, checkout, wishlist features
@@ -654,12 +654,12 @@ Before submitting, thoroughly test your skill.
 
 ### Test Checklist
 
-- [ ] **Basic invocation works** . Skill produces reasonable output
-- [ ] **Template is followed** . Output matches template structure
-- [ ] **Example quality is matched** . Output quality similar to example
-- [ ] **Different contexts work** . Try 3+ different scenarios
-- [ ] **Direct-name invocation works** . `/pm-skills:<name>` on Claude Code or `$<name>` on Codex
-- [ ] **Chains with other skills** . Works as input/output with related skills
+- [ ] **Basic invocation works** - Skill produces reasonable output
+- [ ] **Template is followed** - Output matches template structure
+- [ ] **Example quality is matched** - Output quality similar to example
+- [ ] **Different contexts work** - Try 3+ different scenarios
+- [ ] **Direct-name invocation works** - `/pm-skills:<name>` on Claude Code or `$<name>` on Codex
+- [ ] **Chains with other skills** - Works as input/output with related skills
 
 ### Testing Methods
 
@@ -686,10 +686,10 @@ Use the my-skill skill to create [artifact] for [scenario].
 
 Test with at least:
 
-1. **Minimal context** . Just the basic request
-2. **Rich context** . Detailed background information
-3. **Edge case** . Unusual or challenging scenario
-4. **Different domain** . Another industry or product type
+1. **Minimal context** - Just the basic request
+2. **Rich context** - Detailed background information
+3. **Edge case** - Unusual or challenging scenario
+4. **Different domain** - Another industry or product type
 
 ### What to Look For
 
@@ -953,10 +953,10 @@ docs/templates/skill-template/
 
 ### References
 
-- [Frontmatter Schema](../reference/frontmatter-schema.yaml) . Detailed field documentation
-- [Categories Reference](../reference/categories.md) . Category definitions
-- [agentskills.io Specification](https://agentskills.io/specification) . Base specification
-- [Existing Skills](https://github.com/product-on-purpose/pm-skills/blob/main/AGENTS.md) . See how others are structured
+- [Frontmatter Schema](../reference/frontmatter-schema.yaml) - Detailed field documentation
+- [Categories Reference](../reference/categories.md) - Category definitions
+- [agentskills.io Specification](https://agentskills.io/specification) - Base specification
+- [Existing Skills](https://github.com/product-on-purpose/pm-skills/blob/main/AGENTS.md) - See how others are structured
 
 ### Getting Help
 
@@ -981,4 +981,4 @@ Ready to create a skill? Here's the fast path:
 
 ---
 
-*Part of [PM-Skills](https://github.com/product-on-purpose/pm-skills/blob/main/README.md) . Open source Product Management skills for AI agents*
+*Part of [PM-Skills](https://github.com/product-on-purpose/pm-skills/blob/main/README.md) - Open source Product Management skills for AI agents*

--- a/site/src/content/docs/guides/pm-skill-comparisons.md
+++ b/site/src/content/docs/guides/pm-skill-comparisons.md
@@ -9,13 +9,13 @@ Some skills produce similar-sounding artifacts. These comparisons help you pick 
 
 ## PRD vs Solution Brief
 
-The two most common "spec" documents . but they serve different purposes at different times.
+The two most common "spec" documents - but they serve different purposes at different times.
 
 | | PRD | Solution Brief |
 |---|---|---|
 | **When** | After solution alignment, before engineering starts | During ideation, before committing to an approach |
 | **Audience** | Engineering, QA, stakeholders who need to approve scope | Leadership, cross-functional team, anyone evaluating options |
-| **Depth** | Comprehensive . requirements, scope, technical considerations, timeline | High-level . problem, approach, key metrics, risks |
+| **Depth** | Comprehensive - requirements, scope, technical considerations, timeline | High-level - problem, approach, key metrics, risks |
 | **Length** | 3-8 pages | 1 page |
 | **Includes** | Functional requirements, scope boundaries, dependencies, milestones | Value proposition, key features, success metrics, trade-offs |
 | **Produces** | An engineering-ready specification | A stakeholder alignment document |
@@ -28,13 +28,13 @@ The two most common "spec" documents . but they serve different purposes at diff
 
 ## Hypothesis vs Problem Statement
 
-Both frame the "why" . but one is testable and one is descriptive.
+Both frame the "why" - but one is testable and one is descriptive.
 
 | | Hypothesis | Problem Statement |
 |---|---|---|
 | **Purpose** | State a testable assumption with pass/fail criteria | Articulate the problem and why it matters |
 | **Structure** | "If [action], then [outcome], measured by [metric]" | "Users face [problem] because [cause], resulting in [impact]" |
-| **Testable?** | Yes . has explicit success metrics and a validation plan | No . it describes, it doesn't predict |
+| **Testable?** | Yes - has explicit success metrics and a validation plan | No - it describes, it doesn't predict |
 | **When** | After understanding the problem, before designing the solution | During discovery, before committing to a direction |
 | **Output** | Specific metric targets, experiment design, pass/fail criteria | Problem scope, affected users, business impact, success criteria |
 
@@ -46,14 +46,14 @@ Both frame the "why" . but one is testable and one is descriptive.
 
 ## Competitive Analysis vs Stakeholder Summary
 
-Both involve mapping external entities . but different ones.
+Both involve mapping external entities - but different ones.
 
 | | Competitive Analysis | Stakeholder Summary |
 |---|---|---|
 | **Maps** | Competitors and their products | People and teams who influence your product |
 | **Purpose** | Understand market positioning and feature gaps | Understand who cares, what they need, and how to align them |
 | **Output** | Feature matrix, positioning map, gap analysis | Influence/interest map, profiles, communication plan |
-| **When** | Early discovery . before defining the problem | Before or during any cross-functional initiative |
+| **When** | Early discovery - before defining the problem | Before or during any cross-functional initiative |
 | **Audience** | Product team, marketing, leadership | PM, project lead, anyone managing stakeholder alignment |
 
 **Rule of thumb:** Competitive analysis looks *outward* (market). Stakeholder summary looks *inward* (organization).
@@ -62,11 +62,11 @@ Both involve mapping external entities . but different ones.
 
 ## Edge Cases vs Acceptance Criteria
 
-Both define expected behavior . but at different levels.
+Both define expected behavior - but at different levels.
 
 | | Edge Cases | Acceptance Criteria |
 |---|---|---|
-| **Focus** | What could go wrong . failure modes, boundary conditions | What "done" looks like . expected behavior for the happy path and key scenarios |
+| **Focus** | What could go wrong - failure modes, boundary conditions | What "done" looks like - expected behavior for the happy path and key scenarios |
 | **Format** | Categorized list of scenarios with expected system behavior | Given/When/Then structured scenarios |
 | **Covers** | Error states, empty states, concurrent access, data limits | Functional requirements, user-facing behavior |
 | **When** | After the PRD, during engineering planning | During story writing, before sprint planning |
@@ -80,12 +80,12 @@ Both define expected behavior . but at different levels.
 
 ## Experiment Design vs Instrumentation Spec
 
-Both involve measurement . but at different levels.
+Both involve measurement - but at different levels.
 
 | | Experiment Design | Instrumentation Spec |
 |---|---|---|
-| **Purpose** | Design the test . what to measure, how to split, when to call it | Define the tracking . what events to fire, what properties to capture |
-| **Level** | Strategic . hypothesis, variants, sample size, success criteria | Tactical . event names, schemas, triggers, PII handling |
+| **Purpose** | Design the test - what to measure, how to split, when to call it | Define the tracking - what events to fire, what properties to capture |
+| **Level** | Strategic - hypothesis, variants, sample size, success criteria | Tactical - event names, schemas, triggers, PII handling |
 | **Output** | Experiment plan ready for review | Implementation spec ready for engineering |
 | **When** | Before building the experiment | Before implementing tracking code |
 | **Consumer** | PM, data science, stakeholders | Engineering, analytics platform |
@@ -98,12 +98,12 @@ Both involve measurement . but at different levels.
 
 ## Lessons Log vs Retrospective
 
-Both capture learnings . but different scopes.
+Both capture learnings - but different scopes.
 
 | | Lessons Log | Retrospective |
 |---|---|---|
 | **Scope** | One specific lesson or incident | An entire sprint, project, or milestone |
-| **Depth** | Deep . root cause, impact, recommendations, applicability | Broad . wins, improvements, action items across the whole period |
+| **Depth** | Deep - root cause, impact, recommendations, applicability | Broad - wins, improvements, action items across the whole period |
 | **When** | After a specific event worth documenting | At the end of a sprint or project |
 | **Output** | Structured lesson with root cause and follow-up | Team discussion summary with prioritized actions |
 | **Audience** | Future teams facing similar situations | The current team |

--- a/site/src/content/docs/guides/pm-skill-lifecycle.md
+++ b/site/src/content/docs/guides/pm-skill-lifecycle.md
@@ -11,12 +11,12 @@ A practical guide to creating, validating, iterating, and updating PM skills. Fo
 
 PM skills evolve along two axes:
 
-- **Author axis** . how maintainers create and improve skills in the library (builder → validator → iterator).
-- **Consumer axis** . how users keep their local installation current with the upstream library (updater).
+- **Author axis** - how maintainers create and improve skills in the library (builder → validator → iterator).
+- **Consumer axis** - how users keep their local installation current with the upstream library (updater).
 
 ```mermaid
 flowchart LR
-    subgraph Author["Author axis . evolve the library"]
+    subgraph Author["Author axis - evolve the library"]
         Create["utility-pm-skill-builder<br/>Create"] --> Validate["utility-pm-skill-validate<br/>Validate"]
         Validate --> Decision{Findings?}
         Decision -- "PASS" --> Ship["Ship to repo"]
@@ -26,7 +26,7 @@ flowchart LR
 
     Ship --> Release[(pm-skills<br/>release)]
 
-    subgraph Consumer["Consumer axis . stay current"]
+    subgraph Consumer["Consumer axis - stay current"]
         Release --> Update["utility-update-pm-skills<br/>Update"]
         Update --> Local[(Local<br/>installation)]
     end
@@ -34,9 +34,9 @@ flowchart LR
 
 | Tool | Axis | Command | What it does |
 |------|------|---------|-------------|
-| **Builder** | Author | `/pm-skills:utility-pm-skill-builder` | Creates a new skill from an idea . gap analysis, classification, draft files, staging, promotion |
-| **Validator** | Author | `/pm-skills:utility-pm-skill-validate` | Audits an existing skill against structural conventions and quality criteria . produces a report |
-| **Iterator** | Author | `/pm-skills:utility-pm-skill-iterate` | Applies targeted improvements to an existing skill . previews changes, writes on confirmation |
+| **Builder** | Author | `/pm-skills:utility-pm-skill-builder` | Creates a new skill from an idea - gap analysis, classification, draft files, staging, promotion |
+| **Validator** | Author | `/pm-skills:utility-pm-skill-validate` | Audits an existing skill against structural conventions and quality criteria - produces a report |
+| **Iterator** | Author | `/pm-skills:utility-pm-skill-iterate` | Applies targeted improvements to an existing skill - previews changes, writes on confirmation |
 | **Updater** | Consumer | `/pm-skills:utility-update-pm-skills` | Checks for newer pm-skills releases, previews changes, and applies the update with confirmation |
 
 ### Why four tools instead of one?
@@ -46,7 +46,7 @@ Each tool has a single job. This keeps them focused, independently testable, and
 - The **builder** knows how to create files from scratch but doesn't know how to audit them.
 - The **validator** knows how to assess quality but doesn't modify anything.
 - The **iterator** knows how to apply changes but relies on the validator (or user feedback) to say *what* to change.
-- The **updater** is consumer-side . it doesn't author skills, it propagates upstream changes into a local installation safely (preview, backup, validated copy, value-delta report).
+- The **updater** is consumer-side - it doesn't author skills, it propagates upstream changes into a local installation safely (preview, backup, validated copy, value-delta report).
 
 You can use any tool independently or chain them together.
 
@@ -127,7 +127,7 @@ Validate first to identify what needs work, then iterate to fix it.
 commit and ship
 ```
 
-**When to use:** A skill exists and works but could be better . unclear output contract, incomplete example, vague checklist items.
+**When to use:** A skill exists and works but could be better - unclear output contract, incomplete example, vague checklist items.
 
 ### Pattern 3: Convention Change Rollout
 
@@ -157,7 +157,7 @@ commit and ship
 You received feedback on a skill (from a user, a review, or your own testing). Apply it directly, then validate.
 
 ```
-/pm-skills:utility-pm-skill-iterate deliver-prd "The example uses a B2C scenario but most users are B2B . rewrite with a SaaS enterprise example"
+/pm-skills:utility-pm-skill-iterate deliver-prd "The example uses a B2C scenario but most users are B2B - rewrite with a SaaS enterprise example"
   → Iterator reads current files
   → Normalizes feedback into intended changes (EXAMPLE.md rewrite)
   → Preview → confirm → apply
@@ -168,7 +168,7 @@ You received feedback on a skill (from a user, a review, or your own testing). A
 commit and ship
 ```
 
-**When to use:** You have specific feedback and don't need to audit first . you already know what to change.
+**When to use:** You have specific feedback and don't need to audit first - you already know what to change.
 
 ---
 
@@ -184,7 +184,7 @@ Each skill has its own independent version in its `SKILL.md` frontmatter, follow
 
 **The iterator suggests version bumps** based on what it changed, but doesn't write the version number until you confirm. This prevents compounding bumps when you iterate multiple times before releasing.
 
-**HISTORY.md** is created when a skill ships its second version. It connects versions to efforts and releases. The iterator offers to create or update HISTORY.md at the right moment . you don't need to manage it manually.
+**HISTORY.md** is created when a skill ships its second version. It connects versions to efforts and releases. The iterator offers to create or update HISTORY.md at the right moment - you don't need to manage it manually.
 
 For the full versioning governance, see `docs/internal/skill-versioning.md`.
 
@@ -210,11 +210,11 @@ The repo has CI scripts that run on every push and PR (see `.github/workflows/va
 
 The validator checks skills against two standards:
 
-1. **Current library conventions** . what the shipped library actually does today. These are the checks that matter for structural compliance. Failures here mean something is genuinely wrong.
+1. **Current library conventions** - what the shipped library actually does today. These are the checks that matter for structural compliance. Failures here mean something is genuinely wrong.
 
-2. **The v2.8 standard** . what newly-built skills (created with `/pm-skills:utility-pm-skill-builder`) meet. These are surfaced as WARN or INFO findings on older skills.
+2. **The v2.8 standard** - what newly-built skills (created with `/pm-skills:utility-pm-skill-builder`) meet. These are surfaced as WARN or INFO findings on older skills.
 
-This means **older skills may legitimately receive quality findings** when validated. That's expected . the library converges toward the higher standard over time through the lifecycle, not retroactively. Each iteration brings a skill closer to the current standard.
+This means **older skills may legitimately receive quality findings** when validated. That's expected - the library converges toward the higher standard over time through the lifecycle, not retroactively. Each iteration brings a skill closer to the current standard.
 
 ```mermaid
 flowchart LR

--- a/site/src/content/docs/guides/recipes.md
+++ b/site/src/content/docs/guides/recipes.md
@@ -48,7 +48,7 @@ flowchart LR
 | 2 | `/pm-skills:measure-experiment-design` | A/B test design with variants, metrics, and sample size |
 | 3 | `/pm-skills:measure-instrumentation-spec` | Event tracking spec for your analytics platform |
 | 4 | `/pm-skills:measure-experiment-results` | Statistical analysis with segments and learnings |
-| 5 | `/pm-skills:iterate-pivot-decision` | Ship, iterate, or kill . with evidence |
+| 5 | `/pm-skills:iterate-pivot-decision` | Ship, iterate, or kill - with evidence |
 
 **When to use:** You want to validate an assumption with data before building the full feature.
 
@@ -136,7 +136,7 @@ flowchart LR
 | 2 | `/pm-skills:iterate-lessons-log` | Structured lesson with root cause and recommendations |
 | 3 | `/pm-skills:iterate-refinement-notes` | Next sprint's stories, decisions, and blockers |
 
-**When to use:** End of a sprint or milestone . reflect, learn, and plan.
+**When to use:** End of a sprint or milestone - reflect, learn, and plan.
 
 ---
 

--- a/site/src/content/docs/guides/using-skills.md
+++ b/site/src/content/docs/guides/using-skills.md
@@ -39,7 +39,7 @@ This guide takes you from basic skill invocation to advanced workflows and power
 
 Every skill has three components that work together:
 
-### 1. SKILL.md . The Instructions
+### 1. SKILL.md - The Instructions
 
 This file tells the AI:
 - **What** to create (the artifact type)
@@ -60,7 +60,7 @@ When asked to create a PRD, follow these steps:
    Articulate what success looks like...
 ```
 
-### 2. TEMPLATE.md . The Structure
+### 2. TEMPLATE.md - The Structure
 
 This file provides the exact format for the output:
 - Section headings
@@ -69,7 +69,7 @@ This file provides the exact format for the output:
 
 The AI uses this to ensure consistent, complete outputs.
 
-### 3. EXAMPLE.md . The Quality Benchmark
+### 3. EXAMPLE.md - The Quality Benchmark
 
 A real-world example showing what good looks like:
 - Proper tone and detail level
@@ -842,10 +842,10 @@ Friday:    /pm-skills:iterate-retrospective (team reflection)
 ### Engineering Lead
 
 **Key skills:**
-- `adr` . Document architecture decisions
-- `spike-summary` . Capture exploration findings
-- `edge-cases` . Ensure comprehensive coverage
-- `instrumentation-spec` . Define tracking requirements
+- `adr` - Document architecture decisions
+- `spike-summary` - Capture exploration findings
+- `edge-cases` - Ensure comprehensive coverage
+- `instrumentation-spec` - Define tracking requirements
 
 **Common workflow:**
 ```
@@ -857,9 +857,9 @@ Friday:    /pm-skills:iterate-retrospective (team reflection)
 ### Designer
 
 **Key skills:**
-- `design-rationale` . Document design decisions
-- `jtbd-canvas` . Understand user motivations
-- `interview-synthesis` . Process user research
+- `design-rationale` - Document design decisions
+- `jtbd-canvas` - Understand user motivations
+- `interview-synthesis` - Process user research
 
 **Common workflow:**
 ```
@@ -871,10 +871,10 @@ Friday:    /pm-skills:iterate-retrospective (team reflection)
 ### Data/Analytics
 
 **Key skills:**
-- `experiment-design` . Plan rigorous tests
-- `instrumentation-spec` . Define event tracking
-- `dashboard-requirements` . Specify reporting needs
-- `experiment-results` . Document findings
+- `experiment-design` - Plan rigorous tests
+- `instrumentation-spec` - Define event tracking
+- `dashboard-requirements` - Specify reporting needs
+- `experiment-results` - Document findings
 
 **Common workflow:**
 ```
@@ -914,10 +914,10 @@ Friday:    /pm-skills:iterate-retrospective (team reflection)
 
 ## See Also
 
-- [Getting Started](../getting-started/index.md) . Installation and setup
-- [Categories Reference](../reference/categories.md) . Skill organization
-- [Workflows](../../_workflows/) . Pre-built workflows
+- [Getting Started](../getting-started/index.md) - Installation and setup
+- [Categories Reference](../reference/categories.md) - Skill organization
+- [Workflows](../../_workflows/) - Pre-built workflows
 
 ---
 
-*Part of [PM-Skills](https://github.com/product-on-purpose/pm-skills/blob/main/README.md) . Open source Product Management skills for AI agents*
+*Part of [PM-Skills](https://github.com/product-on-purpose/pm-skills/blob/main/README.md) - Open source Product Management skills for AI agents*

--- a/site/src/content/docs/reference/categories.md
+++ b/site/src/content/docs/reference/categories.md
@@ -533,5 +533,5 @@ Summary of skills across categories:
 
 ## See Also
 
-- [Frontmatter Schema](./frontmatter-schema.yaml) . How to specify categories in skill metadata
-- [Triple Diamond Framework](../concepts/triple-diamond-delivery-process.md) . The primary framework organizing pm-skills
+- [Frontmatter Schema](./frontmatter-schema.yaml) - How to specify categories in skill metadata
+- [Triple Diamond Framework](../concepts/triple-diamond-delivery-process.md) - The primary framework organizing pm-skills

--- a/site/src/content/docs/reference/ecosystem.md
+++ b/site/src/content/docs/reference/ecosystem.md
@@ -100,10 +100,10 @@ pm-skills/
 
 #### Access Methods
 
-1. **Git Clone** . Full access to all files
-2. **ZIP Download** . Upload to Claude.ai, Claude Desktop, etc.
-3. **Slash Commands** . Direct invocation in Claude Code (`deliver-prd`)
-4. **AGENTS.md Discovery** . Auto-discovery in Copilot, Cursor, Windsurf
+1. **Git Clone** - Full access to all files
+2. **ZIP Download** - Upload to Claude.ai, Claude Desktop, etc.
+3. **Slash Commands** - Direct invocation in Claude Code (`deliver-prd`)
+4. **AGENTS.md Discovery** - Auto-discovery in Copilot, Cursor, Windsurf
 
 #### Best For
 
@@ -136,11 +136,11 @@ PM-Skills MCP is an **MCP server** that wraps the skill library, exposing skills
 
 #### Key Capabilities
 
-- **Programmatic Access** . AI invokes tools directly via MCP protocol
-- **Zero Configuration** . Skills are embedded; just install and run
-- **Universal** . Works with any MCP-compatible client
-- **Parameterized** . Tools accept `topic`, `context`, `format`, and `includeExample`
-- **Discoverable** . `pm_list_skills`, `pm_search_skills` for skill exploration
+- **Programmatic Access** - AI invokes tools directly via MCP protocol
+- **Zero Configuration** - Skills are embedded; just install and run
+- **Universal** - Works with any MCP-compatible client
+- **Parameterized** - Tools accept `topic`, `context`, `format`, and `includeExample`
+- **Discoverable** - `pm_list_skills`, `pm_search_skills` for skill exploration
 
 #### Installation
 
@@ -355,9 +355,9 @@ git merge upstream/main
 
 | PM-Skills Version | PM-Skills MCP Version | Compatibility |
 |-------------------|----------------------|---------------|
-| v2.4.x | v2.4.x | **Direct version tracking** . release versions align 1:1 across repos |
-| v2.1.x to v2.3.x | v2.1.x to v2.3.x | **Full alignment** . flat structure, frontmatter-based phase |
-| v2.0.x | v1.1.0 | Partial . nested MCP, flat pm-skills |
+| v2.4.x | v2.4.x | **Direct version tracking** - release versions align 1:1 across repos |
+| v2.1.x to v2.3.x | v2.1.x to v2.3.x | **Full alignment** - flat structure, frontmatter-based phase |
+| v2.0.x | v1.1.0 | Partial - nested MCP, flat pm-skills |
 | v1.2.x | v1.0.x | Legacy stable |
 | v1.1.x | v1.0.x | Legacy compatible |
 | v1.0.x | v1.0.x | Legacy compatible |

--- a/site/src/content/docs/reference/pm-skill-anatomy.md
+++ b/site/src/content/docs/reference/pm-skill-anatomy.md
@@ -36,7 +36,7 @@ Directory names follow the pattern `{prefix}-{skill-name}` where the prefix is t
 
 ## The Three Files
 
-### SKILL.md . The Instructions
+### SKILL.md - The Instructions
 
 The core file. Contains frontmatter metadata and markdown instructions that tell an AI agent how to produce an artifact. Structure:
 
@@ -50,15 +50,15 @@ The core file. Contains frontmatter metadata and markdown instructions that tell
 | Quality Checklist | Verification criteria before finalizing |
 | Examples | References `references/EXAMPLE.md` |
 
-### TEMPLATE.md . The Output Format
+### TEMPLATE.md - The Output Format
 
 Defines the structure of what the skill produces. Contains section headers with guidance comments explaining what goes in each section. The agent fills this template when executing the skill.
 
 CI requirement: must contain at least 3 `##` sections.
 
-### EXAMPLE.md . The Quality Benchmark
+### EXAMPLE.md - The Quality Benchmark
 
-A complete, realistic example of the skill's output. Shows what "good" looks like . not an outline or placeholder, but a fully filled artifact (typically 150-300 lines for complex skills).
+A complete, realistic example of the skill's output. Shows what "good" looks like - not an outline or placeholder, but a fully filled artifact (typically 150-300 lines for complex skills).
 
 ---
 
@@ -134,15 +134,15 @@ PM-skills organizes domain skills across 6 phases of the Triple Diamond framewor
 
 ```mermaid
 graph TD
-    subgraph Diamond1["Diamond 1 . Problem Space"]
+    subgraph Diamond1["Diamond 1 - Problem Space"]
         DISCOVER["**DISCOVER**\n3 skills\nresearch & context"]
         DEFINE["**DEFINE**\n4 skills\nproblem framing"]
     end
-    subgraph Diamond2["Diamond 2 . Solution Space"]
+    subgraph Diamond2["Diamond 2 - Solution Space"]
         DEVELOP["**DEVELOP**\n4 skills\nideation & spec"]
         DELIVER["**DELIVER**\n6 skills\nhandoff & launch"]
     end
-    subgraph Diamond3["Diamond 3 . Learning Space"]
+    subgraph Diamond3["Diamond 3 - Learning Space"]
         MEASURE["**MEASURE**\n5 skills\ndata & testing"]
         ITERATE["**ITERATE**\n4 skills\nlearning & adapting"]
     end
@@ -162,7 +162,7 @@ graph TD
 | Measure | 5 | Experiments, instrumentation, dashboards, results, OKR grading |
 | Iterate | 4 | Retrospectives, lessons, refinement, pivot decisions |
 
-Foundation and utility skills sit outside the phase model . they serve all phases or operate at a meta level.
+Foundation and utility skills sit outside the phase model - they serve all phases or operate at a meta level.
 
 ---
 
@@ -189,15 +189,15 @@ Sections: Foundation Classification, Discover Phase, ..., Iterate Phase, Utility
 ### Workflows (`_workflows/*.md`)
 
 Multi-skill workflows that chain skills together. Nine shipped workflows:
-- **Feature Kickoff** . Quick-start workflow (problem → hypothesis → PRD → stories)
-- **Lean Startup** . Build-Measure-Learn rapid iteration
-- **Triple Diamond** . Complete product development cycle
-- **Customer Discovery** . Research to validated problem
-- **Sprint Planning** . Backlog to sprint-ready stories
-- **Product Strategy** . Competitive context to architecture decisions
-- **Post-Launch Learning** . Measurement to organizational learnings
-- **Stakeholder Alignment** . Leadership buy-in package
-- **Technical Discovery** . Spike to architecture decisions
+- **Feature Kickoff** - Quick-start workflow (problem → hypothesis → PRD → stories)
+- **Lean Startup** - Build-Measure-Learn rapid iteration
+- **Triple Diamond** - Complete product development cycle
+- **Customer Discovery** - Research to validated problem
+- **Sprint Planning** - Backlog to sprint-ready stories
+- **Product Strategy** - Competitive context to architecture decisions
+- **Post-Launch Learning** - Measurement to organizational learnings
+- **Stakeholder Alignment** - Leadership buy-in package
+- **Technical Discovery** - Spike to architecture decisions
 
 ---
 
@@ -262,8 +262,8 @@ For manual creation, follow the structure in [skill template](https://github.com
 
 ## See Also
 
-- [Agent Skill Anatomy](../concepts/agent-skill-anatomy.md) . Spec-level, cross-platform reference (agentskills.io)
-- [Frontmatter Schema](../reference/frontmatter-schema.yaml) . Complete field definitions and validation rules
-- [Category Taxonomy](../reference/categories.md) . Category definitions and framework mappings
-- [Creating PM Skills Guide](../guides/creating-pm-skills.md) . Step-by-step authoring instructions
-- [Getting Started](../getting-started/index.md) . Setup and usage guide
+- [Agent Skill Anatomy](../concepts/agent-skill-anatomy.md) - Spec-level, cross-platform reference (agentskills.io)
+- [Frontmatter Schema](../reference/frontmatter-schema.yaml) - Complete field definitions and validation rules
+- [Category Taxonomy](../reference/categories.md) - Category definitions and framework mappings
+- [Creating PM Skills Guide](../guides/creating-pm-skills.md) - Step-by-step authoring instructions
+- [Getting Started](../getting-started/index.md) - Setup and usage guide

--- a/site/src/content/docs/reference/pm-skill-versioning.md
+++ b/site/src/content/docs/reference/pm-skill-versioning.md
@@ -19,15 +19,15 @@ A repo release packages many skills. A skill can iterate across multiple repo re
 
 ## How Skill Versions Work
 
-Each skill follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html). The "public API" of a skill is its shipped contract . the command name, required output sections, interaction pattern, and output guarantees.
+Each skill follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html). The "public API" of a skill is its shipped contract - the command name, required output sections, interaction pattern, and output guarantees.
 
 ### What triggers each bump
 
 | Bump | When | Examples |
 |------|------|---------|
-| **Major** (X.0.0) | Required contract changed . existing usage breaks | Command renamed, required section removed, interaction pattern changed |
-| **Minor** (x.Y.0) | New optional capability . existing usage still works | New optional output section, handles more scenarios |
-| **Patch** (x.y.Z) | Clarification only . same requirements, better expression | Wording improved, example rewritten, checklist item rephrased |
+| **Major** (X.0.0) | Required contract changed - existing usage breaks | Command renamed, required section removed, interaction pattern changed |
+| **Minor** (x.Y.0) | New optional capability - existing usage still works | New optional output section, handles more scenarios |
+| **Patch** (x.y.Z) | Clarification only - same requirements, better expression | Wording improved, example rewritten, checklist item rephrased |
 
 ### The tie-breaker rule
 
@@ -50,7 +50,7 @@ skills/deliver-prd/
 
 HISTORY.md includes a summary table (newest first) and a section per version describing what changed and why.
 
-Skills on their first version don't need HISTORY.md . the effort brief and skills manifest cover the initial release.
+Skills on their first version don't need HISTORY.md - the effort brief and skills manifest cover the initial release.
 
 ## Skills Manifest
 
@@ -80,8 +80,8 @@ This answers: "Which skill versions shipped in release X?"
 
 The [lifecycle tools](../guides/pm-skill-lifecycle.md) integrate with versioning:
 
-- **`utility-pm-skill-validate`** . reports the current skill version in the validation report header
-- **`utility-pm-skill-iterate`** . suggests a version bump class (patch/minor/major) after applying changes, updates the `version` and `updated` fields on confirmation, and offers to create or update HISTORY.md
+- **`utility-pm-skill-validate`** - reports the current skill version in the validation report header
+- **`utility-pm-skill-iterate`** - suggests a version bump class (patch/minor/major) after applying changes, updates the `version` and `updated` fields on confirmation, and offers to create or update HISTORY.md
 
 ## Current Skill Versions
 

--- a/site/src/content/docs/reference/project-structure.md
+++ b/site/src/content/docs/reference/project-structure.md
@@ -5,13 +5,13 @@ description: High-level walkthrough of the pm-skills repository layout - skills/
 
 ## Table of Contents
 - [Directory Overview](#directory-overview)
-- [/skills/ . Skills](#skills--the-65-pm-skills-flat)
-- [/commands/ . Slash Commands](#commands--slash-commands)
-- [/workflows/ . Workflows](#_workflows--workflows)
-- [/docs/ . Documentation](#docs--documentation)
-- [/templates/ . Skill Templates](#docstemplates--skill-templates)
-- [/_agent-context/ . AI Agent Context](#_agent-context--ai-agent-context)
-- [/.github/ . GitHub Configuration](#github--github-configuration)
+- [/skills/ - Skills](#skills---the-65-pm-skills-flat)
+- [/commands/ - Slash Commands](#commands---slash-commands)
+- [/workflows/ - Workflows](#_workflows---workflows)
+- [/docs/ - Documentation](#docs---documentation)
+- [/templates/ - Skill Templates](#docstemplates---skill-templates)
+- [/_agent-context/ - AI Agent Context](#_agent-context---ai-agent-context)
+- [/.github/ - GitHub Configuration](#github---github-configuration)
 - [Root Files](#root-files)
 - [File Naming Conventions](#file-naming-conventions)
 - [Related Documentation](#related-documentation)
@@ -38,7 +38,7 @@ Note on `agents/` vs `_agent-context/`: these are distinct directories with diff
 
 ---
 
-## `/skills/` . The 65 PM Skills (flat)
+## `/skills/` - The 65 PM Skills (flat)
 
 Skills are the core of PM-Skills. Each skill teaches AI assistants how to produce a specific PM artifact with professional quality.
 
@@ -150,7 +150,7 @@ skills/{skill-name}/
 
 ---
 
-## `/commands/` . Slash Commands
+## `/commands/` - Slash Commands
 
 Contains the 10 `/workflow-*` orchestrator commands. Each `commands/workflow-*.md` chains multiple skills into a guided lifecycle sequence. Individual skills are invoked directly by name in v2.22.0+ (`/pm-skills:<name>` on Claude Code, `$<name>` on Codex), not via per-skill command wrappers.
 
@@ -170,7 +170,7 @@ Contains the 10 `/workflow-*` orchestrator commands. Each `commands/workflow-*.m
 
 ---
 
-## `/_workflows/` . Workflows
+## `/_workflows/` - Workflows
 
 Workflows chain multiple skills together into guided, end-to-end sequences.
 
@@ -188,7 +188,7 @@ Workflows chain multiple skills together into guided, end-to-end sequences.
 
 ---
 
-## `/docs/` . Documentation
+## `/docs/` - Documentation
 
 ```
 docs/
@@ -214,7 +214,7 @@ The `docs/frameworks/` folder was retired in v2.13.0 (Bucket A.1); the canonical
 
 ---
 
-## `/docs/templates/` . Skill Templates
+## `/docs/templates/` - Skill Templates
 
 Starter templates for creating new skills.
 
@@ -230,7 +230,7 @@ Use these templates when contributing a new skill. See [creating-pm-skills.md](.
 
 ---
 
-## `/_agent-context/` . AI Agent Context
+## `/_agent-context/` - AI Agent Context
 
 Session continuity for AI coding assistants. Contains context, decisions, and session logs.
 
@@ -254,7 +254,7 @@ This directory helps AI assistants maintain context across sessions. Not require
 
 ---
 
-## `/.github/` . GitHub Configuration
+## `/.github/` - GitHub Configuration
 
 ```
 .github/

--- a/site/src/content/docs/reference/skill-families/meeting-skills-contract.md
+++ b/site/src/content/docs/reference/skill-families/meeting-skills-contract.md
@@ -205,9 +205,9 @@ attendees:
 ### Input quality levels
 
 ```
-high     . structured notes with clear topics, complete attendee list, explicit decisions and actions captured
-medium   . partial notes, some gaps, requires moderate inference
-low      . fragmentary input, significant inference required, multiple gaps
+high     - structured notes with clear topics, complete attendee list, explicit decisions and actions captured
+medium   - partial notes, some gaps, requires moderate inference
+low      - fragmentary input, significant inference required, multiple gaps
 ```
 
 **Frontmatter field**: `input_quality` (required).
@@ -217,9 +217,9 @@ low      . fragmentary input, significant inference required, multiple gaps
 Same enum used for overall confidence (frontmatter `confidence`) and inline per-section markers:
 
 ```
-high   . directly supported by input
-medium . inferred from multiple contextual cues
-low    . tentative, verify before sharing
+high   - directly supported by input
+medium - inferred from multiple contextual cues
+low    - tentative, verify before sharing
 ```
 
 ### Artifact types

--- a/site/src/content/docs/releases/Release_v2.10.0.md
+++ b/site/src/content/docs/releases/Release_v2.10.0.md
@@ -65,7 +65,7 @@ Key features:
   **39 commands**, and **10 workflows**
 - `_pm-skills/` directory convention added to `.gitignore` (local state
   for update reports and backups)
-- MCP server decoupled from release cycle (M-22) . pm-skills-mcp is
+- MCP server decoupled from release cycle (M-22) - pm-skills-mcp is
   frozen and no longer a release prerequisite
 
 ## Sample Library
@@ -73,13 +73,13 @@ Key features:
 7 new sample outputs added for skills that were missing from the sample
 library. All use the storevine thread (Campaigns feature):
 
-- **deliver-acceptance-criteria** . Given/When/Then ACs for the email template builder
-- **utility-mermaid-diagrams** . flowchart planning worksheet for campaign send approval
-- **utility-slideshow-creator** . JSON deck spec for a campaigns launch presentation
-- **utility-pm-skill-builder** . skill implementation packet for a fictional campaign-analytics skill
-- **utility-pm-skill-validate** . validation report with 2 findings
-- **utility-pm-skill-iterate** . iteration applying the validation findings
-- **utility-update-pm-skills** . update completion report (v2.9.1 → v2.10.0)
+- **deliver-acceptance-criteria** - Given/When/Then ACs for the email template builder
+- **utility-mermaid-diagrams** - flowchart planning worksheet for campaign send approval
+- **utility-slideshow-creator** - JSON deck spec for a campaigns launch presentation
+- **utility-pm-skill-builder** - skill implementation packet for a fictional campaign-analytics skill
+- **utility-pm-skill-validate** - validation report with 2 findings
+- **utility-pm-skill-iterate** - iteration applying the validation findings
+- **utility-update-pm-skills** - update completion report (v2.9.1 → v2.10.0)
 
 Sample library: **84 → 91 samples**, now covering all 32 skills.
 
@@ -89,7 +89,7 @@ slideshow-creator, update-pm-skills).
 ## Infrastructure
 
 - Codex cross-LLM review completed: 1 Blocker, 12 Major, 11 Minor
-  findings . all resolved before release
+  findings - all resolved before release
 - v2.9.1 shipped as a prerequisite (workflows guide, count consistency CI)
 
 ## Skill Inventory

--- a/site/src/content/docs/releases/Release_v2.7.0.md
+++ b/site/src/content/docs/releases/Release_v2.7.0.md
@@ -14,7 +14,7 @@ sidebar:
 
 v2.7.0 is the largest pm-skills release since the v2.0 restructure. It ships **two new skills**, introduces the **utility skill classification**, hardens the **CI pipeline**, cleans up **release packaging**, and delivers a comprehensive **documentation refresh** across the entire public surface.
 
-The headline feature is the **PM Skill Builder** (`/pm-skill-builder`) . the first utility-classified skill, which guides contributors through creating new PM skills interactively. This closes the loop on the skill creation workflow: instead of reverse-engineering existing skills, contributors now have a structured builder with gap analysis, classification guidance, and draft file generation.
+The headline feature is the **PM Skill Builder** (`/pm-skill-builder`) - the first utility-classified skill, which guides contributors through creating new PM skills interactively. This closes the loop on the skill creation workflow: instead of reverse-engineering existing skills, contributors now have a structured builder with gap analysis, classification guidance, and draft file generation.
 
 **By the numbers:**
 - **27 skills** (up from 25): 25 domain + 1 foundation + 1 utility
@@ -30,7 +30,7 @@ The headline feature is the **PM Skill Builder** (`/pm-skill-builder`) . the fir
 
 **What**: A Deliver-phase skill that generates structured Given/When/Then acceptance criteria for user stories or feature slices. Covers happy path, edge cases, error states, and non-functional expectations.
 
-**Why it matters**: Acceptance criteria are the handoff contract between PM and engineering. Vague criteria lead to rework. This skill produces testable, unambiguous scenarios that QA can verify without guessing intent . reducing back-and-forth during sprint execution.
+**Why it matters**: Acceptance criteria are the handoff contract between PM and engineering. Vague criteria lead to rework. This skill produces testable, unambiguous scenarios that QA can verify without guessing intent - reducing back-and-forth during sprint execution.
 
 **Use it**: `/acceptance-criteria "User can reset password via email"`
 
@@ -40,7 +40,7 @@ The headline feature is the **PM Skill Builder** (`/pm-skill-builder`) . the fir
 
 ### New Skill: `utility-pm-skill-builder` (F-05)
 
-**What**: The first utility-classified skill. An interactive builder that guides contributors from a PM skill idea to a complete Skill Implementation Packet . including gap analysis, a Why Gate to prevent duplicates, classification, exemplar-driven drafting, and a staging-to-promotion workflow.
+**What**: The first utility-classified skill. An interactive builder that guides contributors from a PM skill idea to a complete Skill Implementation Packet - including gap analysis, a Why Gate to prevent duplicates, classification, exemplar-driven drafting, and a staging-to-promotion workflow.
 
 **Why it matters**: Before the builder, creating a new PM skill required reverse-engineering existing skills and manually assembling 5+ files across 3 directories. The builder encodes all conventions, runs overlap detection against all 27 existing skills, and produces CI-compliant drafts. It reduces the skill creation process from hours of convention-hunting to a guided conversation.
 
@@ -61,10 +61,10 @@ The headline feature is the **PM Skill Builder** (`/pm-skill-builder`) . the fir
 ### Enhanced CI Validation (M-12)
 
 **What**: Extended the frontmatter linter and added three new validation scripts:
-- `lint-skills-frontmatter` . now checks description word count (20-100) and TEMPLATE.md header count (>=3)
-- `validate-agents-md` . verifies AGENTS.md paths match actual skill directories
-- `validate-commands` . verifies command files reference valid skill paths
-- `check-mcp-impact` . advisory detection of skill changes that may affect the MCP server
+- `lint-skills-frontmatter` - now checks description word count (20-100) and TEMPLATE.md header count (>=3)
+- `validate-agents-md` - verifies AGENTS.md paths match actual skill directories
+- `validate-commands` - verifies command files reference valid skill paths
+- `check-mcp-impact` - advisory detection of skill changes that may affect the MCP server
 
 **Why it matters**: As the skill library grows, manual validation doesn't scale. These scripts catch naming mismatches, orphaned entries, and structural drift before they ship. Every new skill committed in this release passed all four validators on both bash and PowerShell.
 
@@ -85,19 +85,19 @@ The headline feature is the **PM Skill Builder** (`/pm-skill-builder`) . the fir
 ### Utility Skill Classification
 
 **What**: Skills now have three classifications:
-- **Domain** (25 skills) . phase-specific PM activities (discover, define, develop, deliver, measure, iterate)
-- **Foundation** (1 skill) . cross-cutting capabilities that apply across phases
-- **Utility** (1 skill) . meta-skills that operate on the repository, workflow, or other skills
+- **Domain** (25 skills) - phase-specific PM activities (discover, define, develop, deliver, measure, iterate)
+- **Foundation** (1 skill) - cross-cutting capabilities that apply across phases
+- **Utility** (1 skill) - meta-skills that operate on the repository, workflow, or other skills
 
-**Why it matters**: The original two-tier model (domain + foundation) couldn't cleanly accommodate tooling skills like the builder. Utility skills don't produce PM artifacts . they produce *other skills*. The three-tier model is more expressive and sets up the planned Create (F-05) -> Validate (F-10) -> Iterate (F-11) lifecycle.
+**Why it matters**: The original two-tier model (domain + foundation) couldn't cleanly accommodate tooling skills like the builder. Utility skills don't produce PM artifacts - they produce *other skills*. The three-tier model is more expressive and sets up the planned Create (F-05) -> Validate (F-10) -> Iterate (F-11) lifecycle.
 
 ---
 
 ### Documentation Refresh (D-01, D-02)
 
 **What**:
-- **D-01**: New `docs/pm-skill-anatomy.md` . practical guide to pm-skills structure covering directory layout, the three-file model, classification types, frontmatter rules, Triple Diamond phases, the wiring layer, and CI validation.
-- **D-02**: Updated 14 public-facing docs for v2.7.0 accuracy . skill counts, command counts, M-12 script documentation, classification model, skill template modernization, and frontmatter schema with utility examples.
+- **D-01**: New `docs/pm-skill-anatomy.md` - practical guide to pm-skills structure covering directory layout, the three-file model, classification types, frontmatter rules, Triple Diamond phases, the wiring layer, and CI validation.
+- **D-02**: Updated 14 public-facing docs for v2.7.0 accuracy - skill counts, command counts, M-12 script documentation, classification model, skill template modernization, and frontmatter schema with utility examples.
 
 **Why it matters**: Public docs were showing stale counts (25 skills instead of 27), missing the new CI scripts, and had no explanation of utility skills. The new anatomy guide gives contributors a single starting point for understanding how skills work, complementing the spec-level `agent-skill-anatomy.md`.
 
@@ -114,9 +114,9 @@ None. All existing skills, commands, templates, and bundles are unchanged.
 The companion MCP server ([pm-skills-mcp](https://github.com/product-on-purpose/pm-skills-mcp)) is release-pinned and requires a re-embed to pick up v2.7.0 changes:
 
 - **`deliver-acceptance-criteria`** → add as `pm_acceptance_criteria` (standard domain skill)
-- **`utility-pm-skill-builder`** → add as `pm_pm_skill_builder` (strip `utility-` prefix, convert hyphens to underscores, prepend `pm_`). The double `pm_` is intentional . it preserves the skill name intact and stays consistent with the future `pm_agent_skill_builder` (F-09). The builder produces the Skill Implementation Packet as text content; file writing is client-dependent.
+- **`utility-pm-skill-builder`** → add as `pm_pm_skill_builder` (strip `utility-` prefix, convert hyphens to underscores, prepend `pm_`). The double `pm_` is intentional - it preserves the skill name intact and stays consistent with the future `pm_agent_skill_builder` (F-09). The builder produces the Skill Implementation Packet as text content; file writing is client-dependent.
 
-**MCP naming convention update**: the `embed-skills.js` naming function should strip classification prefixes (`foundation-`, `utility-`) in addition to phase prefixes. No prefix deduplication . let skill names pass through intact.
+**MCP naming convention update**: the `embed-skills.js` naming function should strip classification prefixes (`foundation-`, `utility-`) in addition to phase prefixes. No prefix deduplication - let skill names pass through intact.
 
 A matching pm-skills-mcp release should follow to pick up both new skills.
 
@@ -162,8 +162,8 @@ All validators pass on both bash and PowerShell:
 
 ## Canonical References
 
-- `CHANGELOG.md` . version history
-- `docs/releases/Release_v2.7.0.md` . this document
-- `docs/internal/release-plans/v2.7.0/README.md` . internal release governance
-- `docs/internal/release-plans/v2.7.0/decisions.md` . key decisions log
+- `CHANGELOG.md` - version history
+- `docs/releases/Release_v2.7.0.md` - this document
+- `docs/internal/release-plans/v2.7.0/README.md` - internal release governance
+- `docs/internal/release-plans/v2.7.0/decisions.md` - key decisions log
 - Effort briefs: `docs/internal/efforts/` (M-12, M-16, F-05, F-06)

--- a/site/src/content/docs/releases/Release_v2.8.0.md
+++ b/site/src/content/docs/releases/Release_v2.8.0.md
@@ -12,7 +12,7 @@ sidebar:
 
 ## Executive Summary
 
-v2.8.0 completes the **PM skill lifecycle**: **Create → Validate → Iterate**. Building on the PM Skill Builder shipped in v2.7.0, this release adds two companion utility skills . a validator that audits skills against conventions and quality criteria, and an iterator that applies targeted improvements. Together, the three tools form a self-reinforcing system for skill quality.
+v2.8.0 completes the **PM skill lifecycle**: **Create → Validate → Iterate**. Building on the PM Skill Builder shipped in v2.7.0, this release adds two companion utility skills - a validator that audits skills against conventions and quality criteria, and an iterator that applies targeted improvements. Together, the three tools form a self-reinforcing system for skill quality.
 
 The release also introduces **skill versioning governance** (SemVer rules, HISTORY.md, skills-manifest.yaml), **advisory CI** for version tracking, and a **lifecycle guide** documenting workflow patterns.
 
@@ -30,11 +30,11 @@ The release also introduces **skill versioning governance** (SemVer rules, HISTO
 
 **What**: A utility skill that audits an existing pm-skills skill against structural conventions (mirroring CI) and LLM-assessed quality criteria.
 
-**Why it matters**: CI catches structural issues (missing files, bad frontmatter), but can't assess quality . is the output contract complete? Does the example fill all template sections? Are checklist items testable? The validator goes deeper, producing a structured report with severity-graded findings and actionable recommendations that the iterator can consume.
+**Why it matters**: CI catches structural issues (missing files, bad frontmatter), but can't assess quality - is the output contract complete? Does the example fill all template sections? Are checklist items testable? The validator goes deeper, producing a structured report with severity-graded findings and actionable recommendations that the iterator can consume.
 
 **Key design decisions** (informed by Codex review):
 - Pipe-delimited report format (`STATUS | TIER | CHECK-ID | message`) with `Report schema: v1` for forward compatibility
-- Two-tier assessment rebaselined against actual shipped library . validates *current conventions* and surfaces the *v2.8 standard* as suggestions
+- Two-tier assessment rebaselined against actual shipped library - validates *current conventions* and surfaces the *v2.8 standard* as suggestions
 - Tier 2 findings capped at WARN (except placeholder leakage which is objectively grounded)
 - Single-skill detailed mode + batch Tier-1-only summary
 
@@ -52,7 +52,7 @@ The release also introduces **skill versioning governance** (SemVer rules, HISTO
 
 **Key design decisions** (informed by Codex review):
 - Before/after preview with stale-preview guard (re-reads files before writing)
-- Version bump class suggested but not auto-written . prevents compounding across multiple iterations
+- Version bump class suggested but not auto-written - prevents compounding across multiple iterations
 - HISTORY.md creation offered at the second-version trigger point; format validated before append
 - Unified flow with explicit input normalization step
 
@@ -64,7 +64,7 @@ The release also introduces **skill versioning governance** (SemVer rules, HISTO
 
 ### Lifecycle Guide (D-03)
 
-**What**: `docs/pm-skill-lifecycle.md` . a public guide explaining the Create → Validate → Iterate lifecycle.
+**What**: `docs/pm-skill-lifecycle.md` - a public guide explaining the Create → Validate → Iterate lifecycle.
 
 **Why it matters**: Three independent tools need a guide that explains how they work as a system. The guide includes four workflow patterns (new skill, improve existing, convention change, feedback loop), a CI vs validator comparison, and the quality standard model.
 
@@ -76,13 +76,13 @@ The release also introduces **skill versioning governance** (SemVer rules, HISTO
 
 **Why it matters**: As skills iterate through the lifecycle, version history (HISTORY.md) and release manifests (skills-manifest.yaml) need to stay in sync with frontmatter. These scripts catch drift automatically.
 
-Both run with `continue-on-error: true` . advisory for now, blocking once adoption grows.
+Both run with `continue-on-error: true` - advisory for now, blocking once adoption grows.
 
 ---
 
 ### Skill Versioning Governance
 
-**What**: `docs/internal/skill-versioning.md` . defines how skill versions are tracked independently of repo versions.
+**What**: `docs/internal/skill-versioning.md` - defines how skill versions are tracked independently of repo versions.
 
 **Key concepts**:
 - Each skill has its own SemVer version in frontmatter, decoupled from the repo version
@@ -110,8 +110,8 @@ See `docs/pm-skill-lifecycle.md` for detailed workflow patterns.
 ## Infrastructure
 
 - `docs/internal/releases/` renamed to `docs/internal/release-plans/` for clarity (34 files updated)
-- `docs/internal/release-plans/v2.7.0/skills-manifest.yaml` . retroactive first use of manifest convention
-- `docs/internal/release-plans/v2.8.0/` . full release governance with phased execution plan and Codex design review
+- `docs/internal/release-plans/v2.7.0/skills-manifest.yaml` - retroactive first use of manifest convention
+- `docs/internal/release-plans/v2.8.0/` - full release governance with phased execution plan and Codex design review
 - `docs/internal/backlog-canonical.md` updated with v2.8.0 assignments
 
 ---
@@ -122,4 +122,4 @@ See `docs/pm-skill-lifecycle.md` for detailed workflow patterns.
 - Re-embed skills: `scripts/embed-skills.js` against the v2.8.0 tag
 - New tools: `pm_pm_skill_validate`, `pm_pm_skill_iterate`
 - Verify `utility-` prefix stripping produces correct tool names
-- Both new skills read existing skill directories . verify MCP embedded content is sufficient
+- Both new skills read existing skill directories - verify MCP embedded content is sufficient

--- a/site/src/content/docs/releases/Release_v2.8.1.md
+++ b/site/src/content/docs/releases/Release_v2.8.1.md
@@ -7,13 +7,13 @@ sidebar:
 
 **Date**: 2026-04-04
 **Status**: Released
-**Type**: Documentation release . no skill or command behavior changes
+**Type**: Documentation release - no skill or command behavior changes
 
 ---
 
 ## Executive Summary
 
-v2.8.1 launches the **PM Skills documentation site** at [product-on-purpose.github.io/pm-skills](https://product-on-purpose.github.io/pm-skills/). Built with MkDocs Material, the site provides a searchable, navigable, mobile-friendly interface to the entire PM Skills library . including 29 skill pages, 3 interactive "Follow the Product" showcase journeys with 84 real sample outputs, workflow recipes, a skill finder, prompt gallery, and skill comparisons.
+v2.8.1 launches the **PM Skills documentation site** at [product-on-purpose.github.io/pm-skills](https://product-on-purpose.github.io/pm-skills/). Built with MkDocs Material, the site provides a searchable, navigable, mobile-friendly interface to the entire PM Skills library - including 29 skill pages, 3 interactive "Follow the Product" showcase journeys with 84 real sample outputs, workflow recipes, a skill finder, prompt gallery, and skill comparisons.
 
 This is a documentation-only release. No PM skills, slash commands, or MCP tools were changed. No `pm-skills-mcp` update is required.
 
@@ -39,11 +39,11 @@ The site at `product-on-purpose.github.io/pm-skills/` features:
 
 ### Showcase: Follow the Product
 
-Three interactive story pages where readers follow a fictional company through the complete PM lifecycle . from discovery research to pivot decisions. Each step shows the actual prompt and the full artifact output.
+Three interactive story pages where readers follow a fictional company through the complete PM lifecycle - from discovery research to pivot decisions. Each step shows the actual prompt and the full artifact output.
 
-- **Storevine** (B2B ecommerce) . organized prompt style
-- **Brainshelf** (consumer PKM app) . casual prompt style
-- **Workbench** (enterprise collaboration) . structured prompt style
+- **Storevine** (B2B ecommerce) - organized prompt style
+- **Brainshelf** (consumer PKM app) - casual prompt style
+- **Workbench** (enterprise collaboration) - structured prompt style
 
 ### Skill Pages Enhanced
 
@@ -54,25 +54,25 @@ Every skill page now includes:
 
 ### New Guide Pages
 
-- **Skill Finder** . interactive decision tree for choosing the right skill
-- **Recipes** . 7 end-to-end workflows (Pitch a Feature, Run an Experiment, etc.)
-- **Prompt Gallery** . curated prompts in 3 styles with commentary
-- **Skill Comparisons** . PRD vs Solution Brief, Hypothesis vs Problem Statement, etc.
-- **MCP Setup** . user-facing guide for installing and using pm-skills-mcp
+- **Skill Finder** - interactive decision tree for choosing the right skill
+- **Recipes** - 7 end-to-end workflows (Pitch a Feature, Run an Experiment, etc.)
+- **Prompt Gallery** - curated prompts in 3 styles with commentary
+- **Skill Comparisons** - PRD vs Solution Brief, Hypothesis vs Problem Statement, etc.
+- **MCP Setup** - user-facing guide for installing and using pm-skills-mcp
 
 ### Generation Scripts
 
 Two Python scripts keep the site in sync with skill source files:
-- `scripts/generate-skill-pages.py` . generates 29 skill pages + phase indexes + commands reference
-- `scripts/generate-showcase.py` . generates 3 showcase journeys from the sample library
+- `scripts/generate-skill-pages.py` - generates 29 skill pages + phase indexes + commands reference
+- `scripts/generate-showcase.py` - generates 3 showcase journeys from the sample library
 
 ---
 
 ## Infrastructure
 
-- `.github/workflows/deploy-docs.yml` . automated deployment on push
-- `mkdocs.yml` . site configuration with Material theme, plugins (search, privacy, social, tags), and full nav tree
-- `requirements-docs.txt` . Python dependencies (mkdocs-material, pillow, cairosvg)
+- `.github/workflows/deploy-docs.yml` - automated deployment on push
+- `mkdocs.yml` - site configuration with Material theme, plugins (search, privacy, social, tags), and full nav tree
+- `requirements-docs.txt` - Python dependencies (mkdocs-material, pillow, cairosvg)
 
 ---
 

--- a/site/src/content/docs/releases/Release_v2.8.2.md
+++ b/site/src/content/docs/releases/Release_v2.8.2.md
@@ -7,7 +7,7 @@ sidebar:
 
 **Date**: 2026-04-04
 **Status**: Released
-**Type**: Documentation release . no skill or command behavior changes
+**Type**: Documentation release - no skill or command behavior changes
 
 ---
 
@@ -17,7 +17,7 @@ v2.8.2 adds the versioning concepts page to the documentation site and polishes 
 
 ## Added
 
-- `docs/concepts/versioning.md` . explains the two-level versioning model (repo version vs. skill version)
+- `docs/concepts/versioning.md` - explains the two-level versioning model (repo version vs. skill version)
 - Git revision date plugin enabled for CI builds
 - Custom CSS for docs site styling
 

--- a/site/src/content/docs/releases/Release_v2.9.0.md
+++ b/site/src/content/docs/releases/Release_v2.9.0.md
@@ -63,12 +63,12 @@ These join the 3 existing workflows (Feature Kickoff, Lean Startup, Triple Diamo
 
 ## Added
 
-- `scripts/generate-workflow-pages.py` . generates `docs/workflows/` from `_workflows/` with link rewriting
-- `_workflows/README.md` and `docs/workflows/README.md` . directory purpose documentation
+- `scripts/generate-workflow-pages.py` - generates `docs/workflows/` from `_workflows/` with link rewriting
+- `_workflows/README.md` and `docs/workflows/README.md` - directory purpose documentation
 
 ## Migration Guide
 
 1. **Path references:** Replace `_bundles/` with `_workflows/` in any custom scripts or integrations
 2. **Command usage:** Replace `/kickoff` with `/workflow-feature-kickoff`
 3. **Documentation links:** Old `/bundles/*` URLs redirect automatically; update bookmarks when convenient
-4. **MCP server:** No changes needed . MCP tool names (`pm_workflow_*`) were already correct
+4. **MCP server:** No changes needed - MCP tool names (`pm_workflow_*`) were already correct

--- a/site/src/content/docs/releases/Release_v2.9.1.md
+++ b/site/src/content/docs/releases/Release_v2.9.1.md
@@ -22,11 +22,11 @@ invoke, and customize workflows. Replaces the brief section that was embedded
 in `using-skills.md`.
 
 **Key sections:**
-- **Which Workflow Should I Use?** . mermaid decision tree based on project phase, uncertainty level, and audience
-- **Workflow Comparison Matrix** . all 9 workflows compared by use case, skills count, complexity, and duration
-- **Invoking Workflows** . how to run each one via slash commands
-- **Customizing Workflows** . skip steps, add steps, combine workflows
-- **Building Custom Workflows** . create your own `_workflows/*.md` files
+- **Which Workflow Should I Use?** - mermaid decision tree based on project phase, uncertainty level, and audience
+- **Workflow Comparison Matrix** - all 9 workflows compared by use case, skills count, complexity, and duration
+- **Invoking Workflows** - how to run each one via slash commands
+- **Customizing Workflows** - skip steps, add steps, combine workflows
+- **Building Custom Workflows** - create your own `_workflows/*.md` files
 
 ## New: Documentation Count Consistency CI (M-20)
 

--- a/site/src/content/docs/tags.md
+++ b/site/src/content/docs/tags.md
@@ -1,6 +1,6 @@
 ---
 title: Tags
-description: Browse PM skills by tag . phase, category, and classification.
+description: Browse PM skills by tag - phase, category, and classification.
 draft: true
 ---
 


### PR DESCRIPTION
Completes #167 (the site-doc-body portion; CHANGELOG was #168).

Replaces all residual " . " (space-period-space) em-dash-sweep scars in the hand-authored site doc bodies with " - " (24 files, 467 occurrences). Includes scars inside mermaid node labels (which render on the site) and example code fences - all were dash scars, none legitimate code.

## Anchor-aware handling
16 of the scars were in **headings**, which changes their slug (`--` -> `---`). For every such heading I also updated the in-file TOC anchor links so they still resolve:
- `concepts/agent-skill-anatomy.md` (3 Layer headings + TOC)
- `reference/project-structure.md` (7 directory headings + TOC)
- `guides/using-skills.md`, `reference/pm-skill-anatomy.md` (headings changed; no inbound anchor links, verified)

The repo's STRICT_ANCHORS rendered-link check (in CI) is the authoritative verifier that no in-page or cross-file anchor broke.

## Test plan
- [x] 0 " . " remaining in site doc bodies
- [x] no U+2014/U+2013 introduced
- [x] no stale cross-file links to old (double-hyphen) slugs
- [x] only real content changes committed (no line-ending churn)
- [ ] CI green, incl. rendered-link / STRICT_ANCHORS anchor resolution