### PR TITLE
ci: advisory guard against em-dash-sweep ' . ' scars in user-facing prose

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -47,7 +47,16 @@ jobs:
         run: node scripts/gen-resource-index.mjs --check
 
       - name: Run resource-index unit tests
-        run: node --test scripts/gen-resource-index.test.mjs
+        run: node --test scripts/gen-resource-index.test.mjs scripts/check-emdash-scars.test.mjs
+
+      - name: Check for em-dash-sweep scars in user-facing prose (advisory)
+        # Flags the " . " (space-period-space) scar that an earlier em-dash sweep
+        # (commit 8ab0f81) left behind. The no-em-dashes hook blocks em-dash
+        # characters but not this swept-to-period residue. Advisory: warns, does
+        # not block. Scope is tracked hand-authored prose; generated + internal
+        # docs are excluded. Cross-platform Node; runs on both OS legs.
+        continue-on-error: true
+        run: node scripts/check-emdash-scars.mjs
 
       - name: Validate commands (bash)
         if: matrix.os == 'ubuntu-latest'

--- a/scripts/check-emdash-scars.mjs
+++ b/scripts/check-emdash-scars.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Advisory guard against the " . " (space-period-space) em-dash-sweep scar in
+// USER-FACING hand-authored prose.
+//
+// Origin: commit 8ab0f81 (2026-04-22, "em-dash sweep completion") replaced
+// em-dash characters with a spaced period instead of a hyphen, leaving a lone
+// spaced period used as a separator. The no-em-dashes PreToolUse hook blocks the
+// root cause (U+2014 / U+2013 characters) but NOT this swept-to-period residue,
+// so this check catches a regression at CI time. It is advisory by design
+// (wired with continue-on-error): a finding warns, it does not block.
+//
+// Scope: tracked hand-authored prose only. Generated site content is gitignored,
+// so `git ls-files` excludes it automatically. docs/internal is intentionally out
+// of scope (it retains some legitimate in-code-fence periods and heading scars).
+// Fence-aware: lines inside ``` code blocks are skipped, because legitimate code
+// can contain a spaced period (for example `cp -r x . `).
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const ROOTS = ['CHANGELOG.md', 'README.md', 'CONTRIBUTING.md', 'site/src/content/docs'];
+
+function trackedProse() {
+  let out;
+  try {
+    out = execSync(`git ls-files ${ROOTS.join(' ')}`, { encoding: 'utf8' });
+  } catch {
+    return [];
+  }
+  return out.split('\n').filter((f) => /\.(md|mdx)$/i.test(f));
+}
+
+// Return the 1-based line numbers (with text) that contain a spaced-period scar,
+// skipping fenced code blocks. The scar signature is " . " (space, period,
+// space): a lone period used as a separator. Consecutive dots (ellipsis " ... ")
+// do not match, and a normal terminal period ("word. Next") has no leading space
+// so it does not match either.
+export function findScars(text) {
+  const hits = [];
+  let inFence = false;
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    if (/ \. /.test(line)) hits.push({ line: i + 1, text: line.trim() });
+  }
+  return hits;
+}
+
+function main() {
+  const findings = [];
+  for (const f of trackedProse()) {
+    let text;
+    try { text = readFileSync(f, 'utf8'); } catch { continue; }
+    for (const h of findScars(text)) findings.push(`${f}:${h.line}: ${h.text}`);
+  }
+  if (findings.length) {
+    console.error(`check-emdash-scars: ${findings.length} possible spaced-period scar(s) in user-facing prose:`);
+    for (const x of findings) console.error('  ' + x);
+    console.error('Fix: replace the lone spaced period with " - " (or restructure). Origin: commit 8ab0f81.');
+    process.exit(1);
+  }
+  console.log('check-emdash-scars: no spaced-period scars in user-facing prose.');
+}
+
+// CLI guard: only run when executed directly, never when imported by the test.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-emdash-scars.test.mjs
+++ b/scripts/check-emdash-scars.test.mjs
@@ -1,0 +1,30 @@
+// scripts/check-emdash-scars.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findScars } from './check-emdash-scars.mjs';
+
+test('findScars flags a spaced-period scar in prose', () => {
+  const hits = findScars('Discover . 3 skills in this phase');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 1);
+});
+
+test('findScars ignores normal sentence periods (no leading space)', () => {
+  assert.equal(findScars('A sentence. Another one. Done.').length, 0);
+});
+
+test('findScars ignores ellipsis', () => {
+  assert.equal(findScars('wait ... then continue').length, 0);
+});
+
+test('findScars skips fenced code blocks (legitimate periods)', () => {
+  const md = ['prose is fine here', '```bash', 'cp -r src/* . # copy to cwd', 'find . -type f', '```', 'more prose'].join('\n');
+  assert.equal(findScars(md).length, 0);
+});
+
+test('findScars catches a scar outside a fence but not inside', () => {
+  const md = ['intro . scarred', '```', 'code . not flagged', '```'].join('\n');
+  const hits = findScars(md);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 1);
+});


### PR DESCRIPTION
FU3 of the #167 follow-up. Prevents regressions of the spaced-period (" . ") scar that an earlier em-dash sweep (commit 8ab0f81, 2026-04-22) left behind by substituting a period for em-dashes.

- `scripts/check-emdash-scars.mjs`: fence-aware scan for the " . " separator scar in **tracked, hand-authored user-facing prose** (CHANGELOG.md, README.md, CONTRIBUTING.md, site doc bodies). Scope comes from `git ls-files`, so gitignored generated content is excluded automatically; `docs/internal` is intentionally out of scope (it retains some legitimate in-fence periods and heading scars).
- `scripts/check-emdash-scars.test.mjs`: 5 unit tests (scar detection, fence skipping, ellipsis + normal-period exclusion).
- `validation.yml`: wired as an **advisory** step (`continue-on-error: true`) on both OS legs, plus the test added to the unit-test run.

Why advisory: the no-em-dashes PreToolUse hook already blocks the root cause (em-dash characters); this catches the swept-to-period residue, which is lower-stakes and may have rare inline-code false positives, so it warns rather than blocks.

## Test plan
- [x] `node --test scripts/check-emdash-scars.test.mjs` (5/5)
- [x] `node scripts/check-emdash-scars.mjs` exits 0 (user-facing prose is clean after #168/#169)
- [x] YAML validates
- [ ] CI green