### PR TITLE
docs(site): soften changelog frontmatter wording

### DIFF
--- a/site/src/content/docs/changelog.md
+++ b/site/src/content/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-description: Release history for the pm-skills repo: a condensed per-release summary linking to the full root CHANGELOG.md and the per-release notes pages.
+description: Condensed per-release summary of the pm-skills changelog, linking to the full root CHANGELOG.md and the per-release notes pages.
 ---
 
 All notable changes to this project will be documented in this file.

--- a/site/src/content/docs/changelog.md
+++ b/site/src/content/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-description: Keep-a-Changelog-formatted release history for the pm-skills repo. Mirrors the root CHANGELOG.md as a navigable docs-site page.
+description: Release history for the pm-skills repo: a condensed per-release summary linking to the full root CHANGELOG.md and the per-release notes pages.
 ---
 
 All notable changes to this project will be documented in this file.


### PR DESCRIPTION
The site changelog is a curated per-release summary that links to the full root CHANGELOG.md and per-release pages, not a 1:1 mirror. Updates the frontmatter description to say so. Cosmetic; closes the last FU1 nit.