### PR TITLE
ci: extend frontmatter-YAML lint to site doc bodies

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -46,6 +46,13 @@ jobs:
         # Cross-platform Node script: runs on both OS legs (also exercises CRLF/LF).
         run: node scripts/gen-resource-index.mjs --check
 
+      - name: Validate site doc frontmatter YAML (enforcing)
+        # Parse-checks frontmatter in tracked Astro doc bodies (skills front matter
+        # is covered separately by lint-skills-frontmatter). Catches the unquoted
+        # colon-in-value defect early with a clear message, instead of a cryptic
+        # Astro build crash. Cross-platform Node; runs on both OS legs.
+        run: node scripts/check-frontmatter-yaml.mjs --site-docs
+
       - name: Run resource-index unit tests
         run: node --test scripts/gen-resource-index.test.mjs scripts/check-emdash-scars.test.mjs
 

--- a/scripts/check-frontmatter-yaml.mjs
+++ b/scripts/check-frontmatter-yaml.mjs
@@ -3,10 +3,27 @@
 // Reads file paths from argv. Files without frontmatter are skipped (not failed).
 // This catches the unquoted-colon-in-value defect class that github's frontmatter
 // renderer rejects (the byte-0 lint check is structural; this is parse-validity).
+//
+// Pass `--site-docs` to also scan the tracked hand-authored Astro doc bodies
+// (`git ls-files site/src/content/docs`, .md/.mdx). Generated content is
+// gitignored, so it is excluded automatically. This catches the same defect in
+// site pages, which otherwise only surfaces as a cryptic Astro build crash.
 import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import yaml from 'js-yaml';
 
-const files = process.argv.slice(2);
+const files = process.argv.slice(2).filter((a) => a !== '--site-docs');
+if (process.argv.includes('--site-docs')) {
+  try {
+    const tracked = execSync('git ls-files site/src/content/docs', { encoding: 'utf8' })
+      .split('\n')
+      .filter((f) => /\.(md|mdx)$/i.test(f));
+    files.push(...tracked);
+  } catch (err) {
+    console.log(`x --site-docs : could not list site docs - ${String(err.message || err).split('\n')[0]}`);
+    process.exit(1);
+  }
+}
 const failures = [];
 
 for (const file of files) {


### PR DESCRIPTION
Adds a `--site-docs` mode to `check-frontmatter-yaml.mjs` and an enforcing CI step that parse-checks frontmatter in tracked Astro doc bodies (skills are covered separately). Closes the gap exposed in #172, where an unquoted colon in a description surfaced only as a cryptic Astro build crash plus 4 cascading failures. Scope via `git ls-files` excludes gitignored generated content. Verified locally: scans 109 docs, clean; backward-compatible with the existing file-arg callers.

## Test plan
- [x] `--site-docs` exits 0 on current main (clean)
- [x] file-arg mode unchanged
- [ ] CI green (incl. the new step)