### PR TITLE
fix(ci): reconcile pre-tag-validate.ps1 with bash + CI inventory (P0-01/P0-02)

### DIFF
--- a/scripts/pre-tag-validate.ps1
+++ b/scripts/pre-tag-validate.ps1
@@ -14,7 +14,12 @@ $ErrorActionPreference = 'Continue'  # Intentionally not Stop; we want every val
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $Root = Split-Path -Parent $ScriptDir
 
-# Truly-enforcing validators
+# Truly-enforcing validator inventory. MUST stay in sync with pre-tag-validate.sh
+# VALIDATORS (same set, same order). Update BOTH scripts together when adding or
+# retiring an enforcing validator - drift here was the P0-01 defect (this bundle
+# referenced two retired validators, check-internal-link-validity and
+# check-generated-content-untouched, that no longer exist, and omitted
+# check-skill-sample-coverage that bash and CI both enforce).
 $Validators = @(
   @{ Name = 'lint-skills-frontmatter';                       Script = 'lint-skills-frontmatter.ps1';                       Args = @() }
   @{ Name = 'validate-agents-md';                            Script = 'validate-agents-md.ps1';                            Args = @() }
@@ -22,15 +27,14 @@ $Validators = @(
   @{ Name = 'validate-meeting-skills-family';                Script = 'validate-meeting-skills-family.ps1';                Args = @() }
   @{ Name = 'validate-foundation-sprint-skills-family -Strict'; Script = 'validate-foundation-sprint-skills-family.ps1';    Args = @('-Strict') }
   @{ Name = 'validate-design-sprint-skills-family -Strict';  Script = 'validate-design-sprint-skills-family.ps1';          Args = @('-Strict') }
-  @{ Name = 'check-internal-link-validity -Strict';          Script = 'check-internal-link-validity.ps1';                  Args = @('-Strict') }
   @{ Name = 'validate-docs-frontmatter -Strict';             Script = 'validate-docs-frontmatter.ps1';                     Args = @('-Strict') }
   @{ Name = 'check-no-body-h1 -Strict';                      Script = 'check-no-body-h1.ps1';                              Args = @('-Strict') }
   @{ Name = 'check-count-consistency';                       Script = 'check-count-consistency.ps1';                       Args = @() }
   @{ Name = 'check-skill-cross-references';                  Script = 'check-skill-cross-references.ps1';                  Args = @() }
-  @{ Name = 'check-generated-content-untouched';             Script = 'check-generated-content-untouched.ps1';             Args = @() }
   @{ Name = 'validate-script-docs';                          Script = 'validate-script-docs.ps1';                          Args = @() }
   @{ Name = 'validate-version-consistency';                  Script = 'validate-version-consistency.ps1';                  Args = @() }
   @{ Name = 'validate-codex-manifest';                       Script = 'validate-codex-manifest.ps1';                       Args = @() }
+  @{ Name = 'check-skill-sample-coverage';                   Script = 'check-skill-sample-coverage.ps1';                   Args = @() }
 )
 
 $OptionalValidators = @(
@@ -38,6 +42,14 @@ $OptionalValidators = @(
   @{ Name = 'check-workflow-generator-coverage';             Script = 'check-workflow-generator-coverage.ps1';             Args = @() }
   @{ Name = 'check-agents-md-command-sync';                  Script = 'check-agents-md-command-sync.ps1';                  Args = @() }
   @{ Name = 'check-context-currency';                        Script = 'check-context-currency.ps1';                        Args = @() }
+)
+
+# Advisory validators: run for visibility but NEVER affect exit status (parity with
+# pre-tag-validate.sh ADVISORY_VALIDATORS). check-version-references flags any
+# non-current vX.Y.Z; its heuristic matches ~1000+ legitimate provenance refs
+# repo-wide with zero real drift, so it is informational only.
+$AdvisoryValidators = @(
+  @{ Name = 'check-version-references (advisory)';           Script = 'check-version-references.ps1';                      Args = @() }
 )
 
 Write-Host "=== pm-skills pre-tag validator bundle ==="
@@ -76,6 +88,27 @@ function Invoke-Validator {
   }
 }
 
+# Advisory runner: runs the validator for visibility, surfaces only its summary
+# verdict line, and NEVER affects the bundle exit status (parity with run_advisory
+# in pre-tag-validate.sh).
+function Invoke-Advisory {
+  param([hashtable]$V)
+
+  $name = $V.Name
+  $script = Join-Path $ScriptDir $V.Script
+
+  if (-not (Test-Path $script)) {
+    Write-Host "SKIP (advisory, not present): $name"
+    return
+  }
+
+  Write-Host -NoNewline "RUN  $name ... "
+  $output = & pwsh -NoProfile -File $script @($V.Args) 2>&1
+  $verdict = $output | Select-String -Pattern 'PASS:|WARN:|Found [0-9]+ line' | Select-Object -Last 1
+  Write-Host "ADVISORY"
+  if ($verdict) { Write-Host "    $($verdict.Line.Trim())" }
+}
+
 foreach ($v in $Validators) {
   if (-not (Invoke-Validator -V $v -Tier 'required')) { $fail = $true }
 }
@@ -84,6 +117,12 @@ Write-Host ""
 Write-Host "--- v2.15.1+ preventive validators ---"
 foreach ($v in $OptionalValidators) {
   if (-not (Invoke-Validator -V $v -Tier 'optional')) { $fail = $true }
+}
+
+Write-Host ""
+Write-Host "--- advisory (non-blocking; informational only) ---"
+foreach ($v in $AdvisoryValidators) {
+  Invoke-Advisory -V $v
 }
 
 Write-Host ""


### PR DESCRIPTION
## What

Reconcile the PowerShell pre-tag validator bundle with the canonical bash bundle (`pre-tag-validate.sh`) and CI (`validation.yml`).

## Why

The 2026-06-06 Codex repo audit found that `pre-tag-validate.ps1` could never reach "ALL CHECKS PASSED" on Windows:

- It listed two **retired validators as REQUIRED** that no longer exist on disk: `check-internal-link-validity.ps1` and `check-generated-content-untouched.ps1`. Because they sit in the required tier (not the optional tier, which tolerates absence), the bundle failed before it could certify release readiness.
- It **omitted `check-skill-sample-coverage`**, which both the bash bundle and CI enforce.

Net: the canonical local release-readiness entry point on Windows was untrustworthy (audit findings P0-01 and P0-02).

## Changes

- Drop the two phantom required validators.
- Add `check-skill-sample-coverage` (parity with `pre-tag-validate.sh` + CI).
- Restore the advisory tier (`check-version-references`) with a non-blocking advisory runner, matching `pre-tag-validate.sh`.
- Required inventory now matches `pre-tag-validate.sh` exactly, in order; added a sync comment to discourage future drift.

## Verification

`pwsh -NoProfile -File scripts/pre-tag-validate.ps1` -> 14 required PASS, 4 optional PASS, 1 advisory (WARN, non-blocking), `=== ALL CHECKS PASSED ===`, exit 0.

This unblocks the deferred v2.25.1 release, whose runbook runs this bundle.