### PR TITLE
chore: Codex audit follow-ups (P1-01 source-link guard, P1-02 path drift, P1-03 history validator)

### DIFF
--- a/agents/pm-release-conductor.md
+++ b/agents/pm-release-conductor.md
@@ -15,7 +15,7 @@ model: sonnet
 memory: none
 ---
 
-You are `pm-release-conductor`. You walk the maintainer through the full release runbook for a new version tag with 6 explicit gates that pause for confirmation. You re-derive aggregate counters at G0 to catch drift. You chain to `pm-skill-auditor` at G0 (and again at G2.5 verification) and to `pm-changelog-curator` at G2. You refuse to advance past a failed gate. The canonical runbook spec lives at `docs/contributing/release-runbook.md` (D12 referential discipline).
+You are `pm-release-conductor`. You walk the maintainer through the full release runbook for a new version tag with 6 explicit gates that pause for confirmation. You re-derive aggregate counters at G0 to catch drift. You chain to `pm-skill-auditor` at G0 (and again at G2.5 verification) and to `pm-changelog-curator` at G2. You refuse to advance past a failed gate. The canonical runbook spec lives at `site/src/content/docs/contributing/release-runbook.md` (D12 referential discipline).
 
 ## Identity
 
@@ -28,7 +28,7 @@ You are `pm-release-conductor`. You walk the maintainer through the full release
 
 ## The 6 Gates
 
-The canonical gate definitions live at `docs/contributing/release-runbook.md`. Read that file at invocation time. Summary:
+The canonical gate definitions live at `site/src/content/docs/contributing/release-runbook.md`. Read that file at invocation time. Summary:
 
 | Gate | Name | Action | Chain |
 |---|---|---|---|
@@ -39,7 +39,7 @@ The canonical gate definitions live at `docs/contributing/release-runbook.md`. R
 | **G3** | Tag + push | Annotated tag on G2.5-captured SHA; push to origin | None |
 | **G4** | Post-tag hygiene | Plugin install path (P0); marketplace registration (P1); Pages rebuild (P1); UI body reminder (P2); next-cycle stub (P2) | None |
 
-Refer to `docs/contributing/release-runbook.md` section "Gate Definitions" for the full sub-check list per gate.
+Refer to `site/src/content/docs/contributing/release-runbook.md` section "Gate Definitions" for the full sub-check list per gate.
 
 ## Critical Discipline Points
 
@@ -171,12 +171,12 @@ Use `--dry-run` for rehearsals before a real release or for spec verification.
 
 ## Cross-References
 
-- Canonical runbook: `docs/contributing/release-runbook.md` (the conductor reads this at invocation time)
+- Canonical runbook: `site/src/content/docs/contributing/release-runbook.md` (the conductor reads this at invocation time)
 - Behavioral spec: `docs/internal/release-plans/v2.16.0/spec_pm-release-conductor.md`
 - Pre-tag validator bundle: `scripts/pre-tag-validate.{sh,ps1}` (G0 + G2.5 sub-check entry point)
 - Chain children:
   - `agents/pm-skill-auditor.md` (G0 and G2.5 chain target)
   - `agents/pm-changelog-curator.md` (G2 chain target)
 - Chain allowlist: `agents/_chain-permitted.yaml` (contains only `pm-release-conductor`)
-- Runtime components catalog: `docs/reference/runtime-components.md`
+- Runtime components catalog: `site/src/content/docs/reference/runtime-components.md`
 - Dispatch skill for cross-client access: `skills/utility-pm-release-conductor/` ("reference + execute inline" pattern for chain composition on non-Claude clients)

--- a/agents/pm-skill-auditor.md
+++ b/agents/pm-skill-auditor.md
@@ -69,7 +69,7 @@ Count by reading the filesystem:
 - Commands = count of `.md` files in `commands/` excluding `.gitkeep`
 - Sub-agents = count of `.md` files in `agents/` excluding `_chain-permitted.yaml`, README.md
 - Enforcing validators = count of validator scripts that `pre-tag-validate.sh` invokes
-- Family contracts = count of files under `docs/reference/skill-families/` matching `*-contract.md`
+- Family contracts = count of files under `site/src/content/docs/reference/skill-families/` matching `*-contract.md`
 
 Compare these re-derived counts to declared values in:
 
@@ -198,9 +198,9 @@ You are NOT proactive (no `use proactively` in the description). Per D7, only `p
 
 ## Cross-References
 
-- User guide: TBD (no dedicated user guide in Phase 3; see `docs/contributing/release-runbook.md` for chained invocation context)
+- User guide: TBD (no dedicated user guide in Phase 3; see `site/src/content/docs/contributing/release-runbook.md` for chained invocation context)
 - Spec doc: `docs/internal/release-plans/v2.16.0/spec_pm-skill-auditor.md` (canonical behavioral contract; this file is the implementation)
 - Cross-cutting check catalog: `docs/internal/release-plans/v2.16.0/spec_pm-skill-auditor.md#cross-cutting-check-catalog`
-- Runtime components catalog: `docs/reference/runtime-components.md`
+- Runtime components catalog: `site/src/content/docs/reference/runtime-components.md`
 - Dispatch skill for cross-client access: `skills/utility-pm-skill-auditor/SKILL.md` (conditional on Phase 2 GATE B per master plan D30)
 - Pre-tag validator bundle: `scripts/pre-tag-validate.{sh,ps1}` (canonical orchestration entry point)

--- a/scripts/check-root-doc-links.mjs
+++ b/scripts/check-root-doc-links.mjs
@@ -1,16 +1,30 @@
 #!/usr/bin/env node
-// check-root-doc-links.mjs - guard against broken links in repo-root markdown.
+// check-root-doc-links.mjs - guard against broken links in repo-root markdown AND
+// in the raw source surfaces (skills/, agents/, _workflows/, commands/) that agents
+// and GitHub readers consume directly.
 //
 // The repo's other link guards (check-rendered-links.mjs, check-route-parity.mjs)
 // validate the BUILT Astro site under site/dist. They do NOT see repo-root prose
-// like README.md and CHANGELOG.md, which GitHub renders with its own relative-link
-// resolver. That blind spot is how the Pattern S docs relocation (docs/ ->
-// site/src/content/docs/) left ~90 dead links in README.md that nothing caught.
+// like README.md and CHANGELOG.md, nor raw SKILL.md / agent / workflow markdown,
+// which GitHub renders with its own relative-link resolver. That blind spot is how
+// the Pattern S docs relocation (docs/ -> site/src/content/docs/) left ~90 dead
+// links in README.md, and dead docs/reference links across skills and agents, that
+// nothing caught (Codex audit P1-01).
 //
-// This guard closes that gap. For each root doc it checks:
-//   - relative links ([..](path)) resolve to a real file/dir in the repo, and
+// For each scanned doc it checks:
+//   - relative links resolve to a real file/dir (resolved from the FILE's own
+//     directory), and
 //   - our own deployed-site URLs (https://<pages-host>/pm-skills/...) map to a real
 //     route in scripts/route-manifest.txt (the same baseline check-route-parity uses).
+//
+// Pattern S relocation alias: a relative link that resolves into the retired
+//   docs/(reference|guides|concepts)/... tree is accepted when the same tail exists
+//   under site/src/content/docs/... (where gen-site.mjs rewrites it at build time).
+//   This is an explicit, documented exception, not a silent pass: any OTHER
+//   non-resolving relative link fails. (Removing the exception is the deeper fix,
+//   but it is coupled to gen-site's rewrite contract; this guard at least stops the
+//   next Pattern-S-class regression in source files.)
+//
 // External URLs (other hosts), in-page #anchors, and mailto:/tel: are skipped.
 // Anchor fragments on internal links are not resolved (presence-only, by design).
 //
@@ -27,7 +41,10 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 // the canonical public origin the docs site is served from.
 const SITE_PREFIX = 'https://product-on-purpose.github.io' + BASE;
 
-const DOCS = ['README.md', 'CHANGELOG.md', 'CONTRIBUTING.md', 'AGENTS.md', 'QUICKSTART.md'];
+// Root-level prose docs (resolved from the repo root).
+const ROOT_DOCS = ['README.md', 'CHANGELOG.md', 'CONTRIBUTING.md', 'AGENTS.md', 'QUICKSTART.md'];
+// Raw source surfaces consumed directly by agents and GitHub readers (Codex audit P1-01).
+const SOURCE_DIRS = ['skills', 'agents', '_workflows', 'commands'];
 const MANIFEST = path.join(ROOT, 'scripts', 'route-manifest.txt');
 
 // Find broken links in a markdown string. Pure (filesystem + routes injected) so it
@@ -42,6 +59,7 @@ export function findBrokenLinks(text, { routes, sitePrefix, exists }) {
   while ((m = re.exec(clean)) !== null) {
     let target = m[1].trim().split(/\s+/)[0]; // drop optional "title"
     if (!target || target.startsWith('#')) continue;
+    if (/[{}]/.test(target)) continue; // template placeholder (e.g. {{path}}, {release-url}), not a real link
     if (/^(mailto:|tel:)/i.test(target)) continue;
     if (/^https?:\/\//i.test(target)) {
       if (target.startsWith(sitePrefix)) {
@@ -59,6 +77,35 @@ export function findBrokenLinks(text, { routes, sitePrefix, exists }) {
   return out;
 }
 
+// Resolve a relative link target from a source file's directory, honoring the
+// Pattern S relocation alias (docs/(reference|guides|concepts)/... source links
+// point at the old root path but the content now lives under site/src/content/docs/).
+// Exported for unit testing; fileExists(absPath) is injected.
+export function relativeTargetResolves(rel, { fileDir, root, fileExists }) {
+  const decoded = decodeURIComponent(rel);
+  const abs = path.resolve(fileDir, decoded);
+  if (fileExists(abs)) return true;
+  // Pattern S moved the whole published docs/ tree under site/src/content/docs/.
+  // (docs/internal, docs/templates, docs/RESOURCES.md, docs/README.md stayed at root
+  // and are caught by the fileExists(abs) check above, so they never reach here.)
+  const relToRoot = path.relative(root, abs).split(path.sep).join('/');
+  const m = relToRoot.match(/^docs\/(.+)$/);
+  if (m && fileExists(path.resolve(root, 'site', 'src', 'content', 'docs', m[1]))) return true;
+  return false;
+}
+
+// Recursively collect *.md files under a directory (empty if the dir is absent).
+function collectMarkdown(dir) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectMarkdown(full));
+    else if (entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
 function main() {
   if (!fs.existsSync(MANIFEST)) {
     console.error(`check-root-doc-links: route manifest not found at ${MANIFEST}`);
@@ -67,22 +114,26 @@ function main() {
   const routes = new Set(
     fs.readFileSync(MANIFEST, 'utf8').split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
   );
-  const exists = (rel) => fs.existsSync(path.resolve(ROOT, decodeURIComponent(rel)));
+  const fileExists = (abs) => fs.existsSync(abs);
+
+  const files = [
+    ...ROOT_DOCS.map((d) => path.join(ROOT, d)).filter((f) => fs.existsSync(f)),
+    ...SOURCE_DIRS.flatMap((d) => collectMarkdown(path.join(ROOT, d))),
+  ];
 
   let problems = [];
-  const checked = [];
-  for (const file of DOCS) {
-    const full = path.join(ROOT, file);
-    if (!fs.existsSync(full)) continue;
-    checked.push(file);
+  for (const full of files) {
+    const fileDir = path.dirname(full);
+    const exists = (rel) => relativeTargetResolves(rel, { fileDir, root: ROOT, fileExists });
     const found = findBrokenLinks(fs.readFileSync(full, 'utf8'), { routes, sitePrefix: SITE_PREFIX, exists });
-    problems = problems.concat(found.map((p) => ({ file, ...p })));
+    const relFile = path.relative(ROOT, full).split(path.sep).join('/');
+    problems = problems.concat(found.map((p) => ({ file: relFile, ...p })));
   }
 
-  console.log('=== Root Doc Link Check ===');
-  console.log(`checked: ${checked.join(', ')}`);
+  console.log('=== Root + Source Doc Link Check ===');
+  console.log(`scanned: ${files.length} markdown files (root prose + ${SOURCE_DIRS.join('/')})`);
   if (problems.length === 0) {
-    console.log('\nPASS: all relative links resolve and all deployed-site URLs map to a real route.');
+    console.log('\nPASS: all relative links resolve (Pattern S alias honored) and all deployed-site URLs map to a real route.');
     process.exit(0);
   }
   console.log(`\nFAIL: ${problems.length} broken link(s):`);

--- a/scripts/check-root-doc-links.test.mjs
+++ b/scripts/check-root-doc-links.test.mjs
@@ -1,7 +1,8 @@
-// Unit tests for check-root-doc-links.mjs findBrokenLinks().
+// Unit tests for check-root-doc-links.mjs findBrokenLinks() + relativeTargetResolves().
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { findBrokenLinks } from './check-root-doc-links.mjs';
+import path from 'node:path';
+import { findBrokenLinks, relativeTargetResolves } from './check-root-doc-links.mjs';
 
 const routes = new Set(['/getting-started/index.html', '/index.html']);
 const sitePrefix = 'https://product-on-purpose.github.io/pm-skills';
@@ -64,4 +65,57 @@ test('a real link whose text is a code span still gets validated', () => {
   const bad = '[`gone/`](gone/)';
   assert.equal(findBrokenLinks(okay, opts).length, 0);
   assert.equal(findBrokenLinks(bad, opts).length, 1);
+});
+
+test('template placeholders ({{path}}, {release-url}) are not treated as links', () => {
+  // Skill TEMPLATE.md files use brace fill-in tokens; a real path never contains braces.
+  const t = '[a]({{path}}) [b]({release-url}) and a real [c](skills/)';
+  assert.equal(findBrokenLinks(t, opts).length, 0);
+});
+
+// --- relativeTargetResolves: per-file resolution + Pattern S relocation alias ---
+const RR_ROOT = path.resolve('rr-root');
+const RR_FILEDIR = path.join(RR_ROOT, 'skills', 'foo');
+const rrExists = (list) => {
+  const set = new Set(list);
+  return (abs) => set.has(abs);
+};
+
+test('a real sibling link resolves from the file dir', () => {
+  const sib = path.resolve(RR_FILEDIR, '../bar/SKILL.md');
+  assert.equal(
+    relativeTargetResolves('../bar/SKILL.md', { fileDir: RR_FILEDIR, root: RR_ROOT, fileExists: rrExists([sib]) }),
+    true
+  );
+});
+
+test('a retired docs/reference link resolves via the site relocation alias', () => {
+  const sitePath = path.resolve(RR_ROOT, 'site', 'src', 'content', 'docs', 'reference', 'x.md');
+  assert.equal(
+    relativeTargetResolves('../../docs/reference/x.md', { fileDir: RR_FILEDIR, root: RR_ROOT, fileExists: rrExists([sitePath]) }),
+    true
+  );
+});
+
+test('a retired docs/releases link resolves via the site relocation alias', () => {
+  const sitePath = path.resolve(RR_ROOT, 'site', 'src', 'content', 'docs', 'releases', 'Release_v2.24.0.md');
+  assert.equal(
+    relativeTargetResolves('../../docs/releases/Release_v2.24.0.md', { fileDir: RR_FILEDIR, root: RR_ROOT, fileExists: rrExists([sitePath]) }),
+    true
+  );
+});
+
+test('docs/internal (stayed at root) resolves at root, not via the alias', () => {
+  const rootPath = path.resolve(RR_FILEDIR, '../../docs/internal/plan.md');
+  assert.equal(
+    relativeTargetResolves('../../docs/internal/plan.md', { fileDir: RR_FILEDIR, root: RR_ROOT, fileExists: rrExists([rootPath]) }),
+    true
+  );
+});
+
+test('a genuinely missing link resolves nowhere and fails', () => {
+  assert.equal(
+    relativeTargetResolves('../../docs/nope.md', { fileDir: RR_FILEDIR, root: RR_ROOT, fileExists: rrExists([]) }),
+    false
+  );
 });

--- a/scripts/validate-skill-history.ps1
+++ b/scripts/validate-skill-history.ps1
@@ -46,6 +46,40 @@ function Get-FrontmatterValue {
     return $value.Trim('"').Trim("'")
 }
 
+function Get-SkillVersion {
+    param([string[]]$Frontmatter)
+
+    # Resolve the skill version from either shape: prefer a metadata.version nested
+    # under a `metadata:` block (the v2.17+ metadata-nested frontmatter), and fall
+    # back to a top-level `version:`. The older Get-FrontmatterValue only matched a
+    # column-0 `version:`, so it false-negatived nested metadata (Codex audit P1-03).
+    $topVersion = $null
+    $metadataVersion = $null
+    $inMetadata = $false
+
+    foreach ($line in $Frontmatter) {
+        if ($line -match '^version:\s*(.*)$') {
+            if ($null -eq $topVersion) { $topVersion = $matches[1] }
+            $inMetadata = $false
+            continue
+        }
+        if ($line -match '^metadata:\s*$') { $inMetadata = $true; continue }
+        if ($inMetadata) {
+            if ($line -match '^\s+version:\s*(.*)$') {
+                if ($null -eq $metadataVersion) { $metadataVersion = $matches[1] }
+            }
+            elseif ($line -match '^\S') {
+                $inMetadata = $false
+            }
+        }
+    }
+
+    $value = if ($metadataVersion) { $metadataVersion } else { $topVersion }
+    if (-not $value) { return $null }
+    $value = ($value -replace '\s+#.*$', '').Trim()
+    return $value.Trim('"').Trim("'")
+}
+
 function Get-HistoryTableVersions {
     param([string]$Path)
 
@@ -119,7 +153,7 @@ Get-ChildItem -Path (Join-Path $Root "skills") -Directory | ForEach-Object {
         return
     }
 
-    $currentVersion = Get-FrontmatterValue -Frontmatter $frontmatter -Key 'version'
+    $currentVersion = Get-SkillVersion -Frontmatter $frontmatter
     if (-not $currentVersion) {
         Write-Host "[FAIL] $rel : sibling SKILL.md is missing version"
         $Fail = $true

--- a/scripts/validate-skill-history.sh
+++ b/scripts/validate-skill-history.sh
@@ -15,6 +15,24 @@ frontmatter_value() {
     sed -E 's/[[:space:]]+#.*$//; s/^["'"'"']//; s/["'"'"']$//'
 }
 
+skill_version() {
+  # Resolve the skill version from either shape: prefer a metadata.version nested
+  # under a `metadata:` block (the v2.17+ metadata-nested frontmatter), and fall
+  # back to a top-level version. frontmatter_value only matched a column-0
+  # `version:`, so it false-negatived nested metadata (Codex audit P1-03).
+  local meta top
+  meta="$(printf '%s\n' "$frontmatter" | awk '
+    /^metadata:[[:space:]]*$/ { inmeta=1; next }
+    inmeta && /^[[:space:]]+version:[[:space:]]*/ {
+      sub(/^[[:space:]]+version:[[:space:]]*/, ""); print; exit
+    }
+    inmeta && /^[^[:space:]]/ { inmeta=0 }
+  ')"
+  top="$(printf '%s\n' "$frontmatter" | sed -n 's/^version:[[:space:]]*//p' | head -1)"
+  local v="${meta:-$top}"
+  printf '%s' "$v" | sed -E 's/[[:space:]]+#.*$//; s/^["'"'"']//; s/["'"'"']$//'
+}
+
 history_table_versions() {
   local file="$1"
 
@@ -75,7 +93,7 @@ for dir in "$ROOT"/skills/*; do
     continue
   fi
 
-  current_version="$(frontmatter_value version)"
+  current_version="$(skill_version)"
   if [[ -z "$current_version" ]]; then
     echo "✗ $rel : sibling SKILL.md is missing version"
     FAIL=1

--- a/site/src/content/docs/contributing/release-runbook.md
+++ b/site/src/content/docs/contributing/release-runbook.md
@@ -60,7 +60,7 @@ The flowchart shows the happy path (left-to-right vertical sequence) plus the un
 Before invoking the runbook (manually or via `utility-pm-release-conductor v{X.Y.Z}`):
 
 - [ ] Master plan exists at `docs/internal/release-plans/v{target}/plan_v{target}.md` with status block reflecting current state
-- [ ] Release notes drafted at `docs/releases/Release_v{target}.md` (or scheduled for G2)
+- [ ] Release notes drafted at `site/src/content/docs/releases/Release_v{target}.md` (or scheduled for G2)
 - [ ] Phase 0 Adversarial Review completed (Codex or alternate cross-LLM review run against the release-prep state)
 - [ ] Current branch is `main` (or designated release branch)
 - [ ] Local repo is up to date with `origin/main`
@@ -106,7 +106,7 @@ Before invoking the runbook (manually or via `utility-pm-release-conductor v{X.Y
 4. **docs/changelog mirror** - update Astro-rendered changelog mirror to match
 5. **README badges** - version badges in `README.md` updated to target version
 6. **Release plan status** - `plan_v{target}.md` status block updated to `SHIPPED YYYY-MM-DD`
-7. **Release notes** - `docs/releases/Release_v{target}.md` exists; conductor reads it; maintainer confirms quality
+7. **Release notes** - `site/src/content/docs/releases/Release_v{target}.md` exists; conductor reads it; maintainer confirms quality
 8. **Hidden-comment leak check** - grep CHANGELOG.md for `<!-- justification:` (pm-changelog-curator debug comments). Fail if any remain; these are intended for maintainer audit only, not for committed CHANGELOG content.
 
 **Blocker:** any sub-check failure pauses G2.


### PR DESCRIPTION
Addresses three follow-ups from the 2026-06-06 Codex audit (the ones recorded after v2.25.1 shipped).

## P1-03 - `validate-skill-history` nested metadata
Both `.ps1` and `.sh` matched a column-0 `version:`, so the v2.17+ `metadata.version` nested frontmatter false-negatived (`foundation-prioritized-action-plan` FAILed). They now prefer `metadata.version`, fall back to top-level. Verified: validator passes (exit 0).

## P1-02 - stale post-Pattern-S paths
`agents/pm-release-conductor.md`, `agents/pm-skill-auditor.md`, and the release runbook cited the retired root `docs/{contributing,reference,releases}/` paths. Repointed to `site/src/content/docs/...`. (This drift bit live during the v2.25.1 release: the conductor pointed `Read` at a runbook path that no longer existed, and the auditor counted family contracts at a 0-file path.)

## P1-01 - extend `check-root-doc-links.mjs` to source surfaces
Beyond root prose, it now scans `skills/`, `agents/`, `_workflows/`, `commands/` (245 files), resolving each link from its own directory with:
- an explicit, documented **Pattern S relocation alias** (`docs/<tail>` that moved under `site/src/content/docs/<tail>`), so the intentionally-rewritten links pass while genuine breakage fails, and
- a skip for brace template placeholders (`{{path}}`, `{release-url}`).

6 new unit tests (16 total, all green). Triage on first run surfaced exactly 8 flags: 2 brace placeholders + 6 relocated `docs/releases` / `docs/contributing` links, all handled.

## Deferred
Spec A (a single validator manifest unifying bash/pwsh/CI inventories) is a larger refactor; the bundles are reconciled by hand (#174) today, so this is a hardening nicety, not a fix.