### PR TITLE
chore(ci): unify validator inventory into a single manifest (audit Spec A)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -382,3 +382,16 @@ jobs:
         run: |
           node --test scripts/check-root-doc-links.test.mjs
           node scripts/check-root-doc-links.mjs
+
+      - name: Check validator-inventory parity (enforcing; bash/pwsh/CI vs manifest)
+        # The release gate has three hand-maintained SHELL-validator inventories:
+        # pre-tag-validate.sh, pre-tag-validate.ps1, and this workflow. They drifted
+        # before (P0-01/P0-02). scripts/validation-manifest.yaml is now the single
+        # source of truth; this referee FAILS if any inventory drifts from it, so the
+        # bash and pwsh bundles cannot list different sets and CI cannot add or drop a
+        # shell validator without updating the manifest. Pure node builtins + js-yaml
+        # (root dep, installed above); cross-OS.
+        if: always()
+        run: |
+          node --test scripts/check-validator-parity.test.mjs
+          node scripts/check-validator-parity.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/validation-manifest.yaml`: a single source of truth for the release-gate shell-validator inventory. Declares every `scripts/*.sh` + `*.ps1` validator once with its local pre-tag tier, CI level, and per-shell flags.
+- `scripts/check-validator-parity.mjs` (+ unit tests), wired enforcing in CI on both OS legs: a referee that fails the build if the bash bundle (`scripts/pre-tag-validate.sh`), the PowerShell bundle (`scripts/pre-tag-validate.ps1`), or `.github/workflows/validation.yml` drifts from the manifest. The two local pre-tag bundles can no longer list different validator sets, and CI cannot add or drop a shell validator without updating the manifest. Pure Node builtins plus `js-yaml` (the existing root tooling dependency).
+
+### Fixed
+
+- Reconciled live drift between the local pre-tag bundles and CI: `validate-skill-family-registration` and `validate-plugin-install` were enforcing in `.github/workflows/validation.yml` but absent from both `scripts/pre-tag-validate.sh` and `scripts/pre-tag-validate.ps1`, so a local "ALL CHECKS PASSED" could still meet a red CI leg on a release PR. Both validators are now in the required tier of both bundles, and the new parity referee prevents the gap from recurring.
+
 ## [2.25.1] - 2026-06-06
 
 **Maintenance patch: banks accumulated untagged work since v2.25.0.** A documentation-site internal reorg to the Product on Purpose family layout (Pattern S) with full family-standard conformance, a generated resource index and `docs/` front door, repaired root-document links plus a CI guard, an em-dash-sweep scar cleanup across user-facing and internal prose with new advisory and enforcing guards to keep them out, three site dependency bumps, and a pre-tag validator parity fix. No skill behavior change and no published-URL change: every page slug and the redirect map are preserved (route parity verified before and after). The catalog stays 65 skills / 5 sub-agents. PATCH.

--- a/docs/internal/audit/2026-06-06_codex.md
+++ b/docs/internal/audit/2026-06-06_codex.md
@@ -258,7 +258,7 @@ Examples:
 
 Do not keep three hand-maintained validator inventories.
 
-> **🔵 CLAUDE - CONFIRMED.** Set difference verified exactly: bash-only `{check-skill-sample-coverage}`; ps1-only `{the two phantom scripts}`; CI is a strict superset of both. PR #174 made the ps1 REQUIRED inventory mirror bash exactly and added a sync comment. The deeper fix (a single validator manifest, your Spec A) is NOT yet done and is a worthwhile follow-up; #174 reconciled the two bundles by hand, it did not unify their source.
+> **🔵 CLAUDE - CONFIRMED.** Set difference verified exactly: bash-only `{check-skill-sample-coverage}`; ps1-only `{the two phantom scripts}`; CI is a strict superset of both. PR #174 made the ps1 REQUIRED inventory mirror bash exactly and added a sync comment. The deeper fix (a single validator manifest, your Spec A) SHIPPED 2026-06-09: `scripts/validation-manifest.yaml` (single source of truth) + `scripts/check-validator-parity.mjs` (CI drift-gate, enforcing on both OS legs). #174 reconciled the two bundles by hand; Spec A unified their source and caught the residual CI-only drift (`validate-skill-family-registration`, `validate-plugin-install`).
 
 ### P1-01 - Source links point to `docs/reference/...`, but the root docs tree no longer has `docs/reference`
 

--- a/docs/internal/audit/2026-06-06_codex_review.md
+++ b/docs/internal/audit/2026-06-06_codex_review.md
@@ -27,7 +27,7 @@ The single most decision-relevant output was a collision between the audit and t
 | Finding | Verdict | Disposition |
 |---|---|---|
 | **P0-01** ps1 pre-tag references 2 missing required scripts | CONFIRMED | FIXED in PR #174; banked in v2.25.1 |
-| **P0-02** bash/ps1/CI inventories diverge | CONFIRMED | Reconciled by hand in #174; single-manifest (Spec A) still a follow-up |
+| **P0-02** bash/ps1/CI inventories diverge | CONFIRMED | Reconciled by hand in #174; single-manifest (Spec A) SHIPPED 2026-06-09: `scripts/validation-manifest.yaml` + `scripts/check-validator-parity.mjs` (CI drift-gate) |
 | **P1-01** broken `docs/reference` source links (41 files / 128 matches) | CONFIRMED + refined | Open follow-up: extend `check-root-doc-links.mjs` scope |
 | **P1-02** `pm-skill-auditor.md:72` stale path | CONFIRMED | Open follow-up |
 | **P1-03** `validate-skill-history` misses `metadata.version` (both .ps1 and .sh) | CONFIRMED (live run) | Open follow-up; muted today (continue-on-error, not in pre-tag bundle) |
@@ -73,4 +73,4 @@ The "Academic work" section cites four arXiv IDs with future-dated `YYMM` prefix
 3. Update `agents/pm-skill-auditor.md:72` and the release runbook/conductor to the `site/src/content/docs/...` paths (P1-02 plus the live runbook-path drift this review surfaced).
 4. Correct the CLAUDE.md/MEMORY "internal notes are gitignored" claim.
 5. Consider the static Skill Finder + `skill-manifest.json` and optional output schemas as next-minor (v2.26.0) candidates; treat broad connectors as out of scope per MCP-maintenance-mode.
-6. Unify the validator inventory into a single manifest (audit Spec A) so bash/ps1/CI cannot drift again.
+6. **DONE (2026-06-09):** Unified the validator inventory into a single manifest (audit Spec A) so bash/ps1/CI cannot drift again: `scripts/validation-manifest.yaml` (source of truth) + `scripts/check-validator-parity.mjs` (referee, enforcing in CI). Reconciled the two validators (`validate-skill-family-registration`, `validate-plugin-install`) that were enforcing in CI but absent from both local bundles.

--- a/docs/internal/release-plans/_unreleased/validator-manifest.md
+++ b/docs/internal/release-plans/_unreleased/validator-manifest.md
@@ -1,0 +1,37 @@
+# Validator-Inventory Manifest (audit Spec A)
+
+**Status:** SHIPPED to branch `chore/spec-a-validator-manifest` (PR pending); banked for the next maintenance tag. Untagged maintenance, no consumable-surface change (catalog stays 65 skills / 5 sub-agents).
+**Created:** 2026-06-09
+**Owner:** Maintainers
+**Type:** infrastructure (release-gate integrity)
+**Origin:** the 2026-06-06 Codex audit, Spec A (closes P0-02). The last open audit follow-up; P0-01 shipped in v2.25.1 and P1-01..P1-03 in PR #178.
+
+---
+
+## 1. The problem
+
+The release gate had three hand-maintained shell-validator inventories: `scripts/pre-tag-validate.sh`, `scripts/pre-tag-validate.ps1`, and `.github/workflows/validation.yml`. They drifted before (P0-01: the ps1 bundle referenced two retired validators and omitted one; P0-02: the three ran materially different sets). PR #174 reconciled bash to ps1 by hand but bound nothing to CI, so they could drift again, and had: `validate-skill-family-registration` and `validate-plugin-install` were enforcing in CI yet absent from both local bundles, so a local "ALL CHECKS PASSED" could still meet a red CI leg.
+
+## 2. What shipped
+
+- `scripts/validation-manifest.yaml`: the single source of truth. Each shell validator is declared once with its `pre_tag` tier (required / optional / advisory, or omitted for CI-only), `ci` level (enforcing / advisory), and per-shell args.
+- `scripts/check-validator-parity.mjs` (+ `check-validator-parity.test.mjs`, 11 tests): the referee. Parses the manifest plus both bundles plus `validation.yml` and fails on any drift (tier-set, flag, CI presence, or enforcing-level). Pure Node builtins plus `js-yaml`; runs enforcing in CI on both OS legs.
+- Reconciliation: added the two drifted validators to the required tier of both bundles, and pointed each bundle's inventory comment at the manifest.
+
+## 3. Decisions
+
+- **Drift-gate, not codegen.** Keep the hand-tuned shell runners (color, `--skip`, advisory verdict extraction) and add a referee, rather than generating the bundles from the manifest. Matches the repo's existing drift-gate idiom (`check-route-parity.mjs`, `gen-resource-index.mjs --check`); lower risk than rewriting two working shell scripts.
+- **Manifest scope is shell validators only.** Node (`.mjs`) checks, the Astro build, and unit-test steps run once cross-platform with no two-shell duplication, so they sit outside the two-shell-parity remit and remain in `validation.yml` only.
+- **Surfaces, not a flat list.** The audit's "all three identical" framing was refined: CI legitimately runs build and Node checks the pure-shell bundle omits, so each validator declares a surface (pre-tag tier vs CI-only) and the referee compares per-surface.
+
+## 4. Acceptance (all met, verified locally)
+
+- [x] PowerShell pre-tag passes (`ALL CHECKS PASSED`, exit 0; both new validators PASS).
+- [x] Bash pre-tag passes (`ALL CHECKS PASSED`, exit 0).
+- [x] Both bundles list the same required validator IDs (referee-enforced; 16 required / 4 optional / 1 advisory).
+- [x] CI cannot add a shell validator without updating the manifest (referee checks manifest-to-CI and CI-to-manifest; wired into `validation.yml`).
+
+## 5. Links
+
+- Source of truth: `scripts/validation-manifest.yaml`; referee: `scripts/check-validator-parity.mjs` (+ test).
+- Audit: `docs/internal/audit/2026-06-06_codex.md` (Spec A, P0-02) and its review `docs/internal/audit/2026-06-06_codex_review.md` (follow-up 6).

--- a/scripts/check-validator-parity.mjs
+++ b/scripts/check-validator-parity.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// check-validator-parity.mjs - the validator-inventory drift referee.
+//
+// WHY THIS EXISTS
+// The release gate has three hand-maintained validator inventories that must
+// agree about which shell validators run and how:
+//   1. scripts/pre-tag-validate.sh   (bash local pre-tag bundle)
+//   2. scripts/pre-tag-validate.ps1  (PowerShell local pre-tag bundle)
+//   3. .github/workflows/validation.yml  (CI)
+// They drifted before: P0-01 (pre-tag-validate.ps1 listed two retired validators
+// and omitted check-skill-sample-coverage) and P0-02 (the three inventories ran
+// materially different sets). PR #174 reconciled bash<->ps1 by hand, but nothing
+// binds them to each other or to CI, so they can silently drift again.
+//
+// WHAT IT DOES
+// scripts/validation-manifest.yaml is the single source of truth: it declares
+// every release-gate shell validator (.sh/.ps1) once, with its local pre-tag tier
+// (required|optional|advisory), its per-shell flags, and its CI level
+// (enforcing|advisory). This referee parses the manifest plus the three consumers
+// and FAILS if any consumer drifts from the manifest:
+//   - a pre-tag bundle omits/adds a validator vs the manifest's pre_tag set
+//   - a pre-tag bundle invokes a validator with different flags than declared
+//   - a manifest ci: entry has no matching step in validation.yml (or vice-versa)
+//   - a validator's CI enforcing-level disagrees with the manifest
+// So "CI cannot add a required validator without updating the manifest", and the
+// bash and PowerShell bundles cannot list different sets, by construction.
+//
+// SCOPE: shell validators only (scripts/*.sh + scripts/*.ps1). Node (.mjs) checks,
+// the site build, and unit-test steps are CI-orchestration concerns that run once
+// cross-platform (no two-shell duplication), so they are out of the manifest's
+// two-shell-parity remit by design. See validation-manifest.yaml header.
+//
+// Pure node builtins (+ js-yaml, a declared root devDependency) so it runs on both
+// OS legs. The parsers + computeParity are exported and unit-tested in
+// check-validator-parity.test.mjs; the CLI shell below is intentionally untested,
+// matching check-root-doc-links.mjs.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const TIERS = ['required', 'optional', 'advisory'];
+
+// --- parsers -------------------------------------------------------------
+
+// Capture the body between `NAME=(` and the next line that is just `)`. Anchored
+// to a line start so VALIDATORS does not match inside OPTIONAL_VALIDATORS.
+function bashArrayBody(text, name) {
+  const re = new RegExp('(?:^|\\n)' + name + '=\\(([\\s\\S]*?)\\n\\)', 'm');
+  const m = text.match(re);
+  return m ? m[1] : '';
+}
+
+function bashEntries(body) {
+  const entries = [];
+  for (const line of body.split('\n')) {
+    // Each entry is "<display>|<cmd>"; derive the id from the script path so the
+    // "(advisory)" display suffix and the leading $ROOT/ are ignored.
+    const m = line.match(/scripts\/([\w-]+)\.sh([^"]*)/);
+    if (!m) continue;
+    const id = m[1];
+    const args = m[2].trim().split(/\s+/).filter(Boolean);
+    entries.push({ id, args });
+  }
+  return entries;
+}
+
+export function parseBashBundle(text) {
+  return {
+    required: bashEntries(bashArrayBody(text, 'VALIDATORS')),
+    optional: bashEntries(bashArrayBody(text, 'OPTIONAL_VALIDATORS')),
+    advisory: bashEntries(bashArrayBody(text, 'ADVISORY_VALIDATORS')),
+  };
+}
+
+// `$Validators` does not match inside `$OptionalValidators` because the `$` must
+// sit immediately before the name.
+function pwshArrayBody(text, name) {
+  const re = new RegExp('\\$' + name + '\\s*=\\s*@\\(([\\s\\S]*?)\\n\\)', 'm');
+  const m = text.match(re);
+  return m ? m[1] : '';
+}
+
+function pwshEntries(body) {
+  const entries = [];
+  for (const line of body.split('\n')) {
+    const sm = line.match(/Script\s*=\s*'([\w-]+)\.ps1'/);
+    if (!sm) continue;
+    const id = sm[1];
+    const am = line.match(/Args\s*=\s*@\(([^)]*)\)/);
+    const args = am ? (am[1].match(/'([^']*)'/g) || []).map((q) => q.slice(1, -1)) : [];
+    entries.push({ id, args });
+  }
+  return entries;
+}
+
+export function parsePwshBundle(text) {
+  return {
+    required: pwshEntries(pwshArrayBody(text, 'Validators')),
+    optional: pwshEntries(pwshArrayBody(text, 'OptionalValidators')),
+    advisory: pwshEntries(pwshArrayBody(text, 'AdvisoryValidators')),
+  };
+}
+
+// Split validation.yml into `- name:` step blocks. A validator is advisory in CI
+// when its step carries `continue-on-error: true`. A validator runs on two legs
+// (bash + pwsh) in separate blocks; it is treated as enforcing if any leg enforces.
+export function parseCiWorkflow(text) {
+  const blocks = text.split(/\n[ \t]*- name:/).slice(1);
+  const byId = new Map();
+  for (const block of blocks) {
+    const enforcing = !/continue-on-error:\s*true/.test(block);
+    for (const raw of block.split('\n')) {
+      const line = raw.trim();
+      if (line.startsWith('#')) continue; // skip comments referencing script paths
+      const re = /scripts\/([\w-]+)\.(?:sh|ps1)\b/g;
+      let m;
+      while ((m = re.exec(line))) {
+        const id = m[1];
+        const prev = byId.get(id);
+        byId.set(id, { id, enforcing: (prev ? prev.enforcing : false) || enforcing });
+      }
+    }
+  }
+  return [...byId.values()];
+}
+
+// --- the verdict ---------------------------------------------------------
+
+export function computeParity({ manifest, bash, pwsh, ci }) {
+  const findings = [];
+  const mById = new Map(manifest.map((e) => [e.id, e]));
+
+  const manifestPreTag = { required: [], optional: [], advisory: [] };
+  for (const e of manifest) {
+    if (e.pre_tag) manifestPreTag[e.pre_tag].push(e.id);
+  }
+
+  for (const [shell, bundle, argKey] of [
+    ['bash', bash, 'bash'],
+    ['pwsh', pwsh, 'pwsh'],
+  ]) {
+    for (const tier of TIERS) {
+      const bundleIds = new Set(bundle[tier].map((e) => e.id));
+      const manifestIds = new Set(manifestPreTag[tier]);
+      for (const id of manifestIds) {
+        if (!bundleIds.has(id)) {
+          findings.push(`${shell} bundle is missing ${tier} validator "${id}" declared in the manifest`);
+        }
+      }
+      for (const id of bundleIds) {
+        if (!manifestIds.has(id)) {
+          findings.push(`${shell} bundle lists "${id}" in ${tier} but the manifest does not declare it pre_tag: ${tier}`);
+        }
+      }
+      for (const entry of bundle[tier]) {
+        const m = mById.get(entry.id);
+        if (!m) continue;
+        const expected = (m[argKey] && m[argKey].args) || [];
+        if (JSON.stringify(expected) !== JSON.stringify(entry.args)) {
+          findings.push(
+            `${shell} bundle invokes "${entry.id}" with args [${entry.args.join(' ')}] but the manifest declares [${expected.join(' ')}] (arg drift)`
+          );
+        }
+      }
+    }
+  }
+
+  const ciById = new Map(ci.map((e) => [e.id, e]));
+  for (const e of manifest) {
+    if (!e.ci) continue;
+    if (!ciById.has(e.id)) {
+      findings.push(`manifest declares ci: ${e.ci} for "${e.id}" but no matching shell step exists in validation.yml`);
+      continue;
+    }
+    const actual = ciById.get(e.id).enforcing ? 'enforcing' : 'advisory';
+    if (actual !== e.ci) {
+      findings.push(`"${e.id}" is ${actual} in validation.yml but the manifest declares ci: ${e.ci} (enforcing-level drift)`);
+    }
+  }
+  for (const e of ci) {
+    const m = mById.get(e.id);
+    if (!m || !m.ci) {
+      findings.push(`validation.yml runs shell validator "${e.id}" but it is not declared (with a ci: level) in the manifest`);
+    }
+  }
+
+  return findings;
+}
+
+// --- CLI shell (untested; reads the live files) --------------------------
+
+function main() {
+  // Lazy-require js-yaml so importing the pure functions in tests never needs it.
+  return import('js-yaml').then((yamlMod) => {
+    const yaml = yamlMod.default;
+    const root = path.resolve(url.fileURLToPath(new URL('.', import.meta.url)), '..');
+    const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+    const manifest = yaml.load(read('scripts/validation-manifest.yaml'));
+    const bash = parseBashBundle(read('scripts/pre-tag-validate.sh'));
+    const pwsh = parsePwshBundle(read('scripts/pre-tag-validate.ps1'));
+    const ci = parseCiWorkflow(read('.github/workflows/validation.yml'));
+
+    const findings = computeParity({ manifest, bash, pwsh, ci });
+
+    if (findings.length === 0) {
+      console.log('PASS: validator inventories (bash, pwsh, CI) match scripts/validation-manifest.yaml');
+      process.exit(0);
+    }
+    console.error(`FAIL: ${findings.length} validator-inventory drift(s) vs scripts/validation-manifest.yaml:\n`);
+    for (const f of findings) console.error(`  - ${f}`);
+    console.error('\nFix: update scripts/validation-manifest.yaml and the drifted inventory so they agree.');
+    process.exit(1);
+  });
+}
+
+// Run only when invoked directly, not when imported by the test.
+if (process.argv[1] && url.pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main();
+}

--- a/scripts/check-validator-parity.test.mjs
+++ b/scripts/check-validator-parity.test.mjs
@@ -1,0 +1,178 @@
+// Unit tests for check-validator-parity.mjs - the validator-inventory drift referee.
+//
+// These tests exercise the pure functions only (parsers + computeParity); the CLI
+// shell (file reads, process.exit) is intentionally untested, matching the repo's
+// convention (see check-root-doc-links.test.mjs). Fixtures are minimal inline
+// strings shaped like the real pre-tag-validate.{sh,ps1} arrays and validation.yml
+// steps, so a parser regression is caught without depending on the live files.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseBashBundle,
+  parsePwshBundle,
+  parseCiWorkflow,
+  computeParity,
+} from './check-validator-parity.mjs';
+
+// --- fixtures: tiny stand-ins for the three real inventories ---
+
+const BASH_FIXTURE = `
+VALIDATORS=(
+  "lint-skills-frontmatter|bash $ROOT/scripts/lint-skills-frontmatter.sh"
+  "validate-docs-frontmatter --strict|bash $ROOT/scripts/validate-docs-frontmatter.sh --strict"
+)
+OPTIONAL_VALIDATORS=(
+  "check-context-currency|bash $ROOT/scripts/check-context-currency.sh"
+)
+ADVISORY_VALIDATORS=(
+  "check-version-references (advisory)|bash $ROOT/scripts/check-version-references.sh"
+)
+`;
+
+const PWSH_FIXTURE = `
+$Validators = @(
+  @{ Name = 'lint-skills-frontmatter';          Script = 'lint-skills-frontmatter.ps1';  Args = @() }
+  @{ Name = 'validate-docs-frontmatter -Strict'; Script = 'validate-docs-frontmatter.ps1'; Args = @('-Strict') }
+)
+$OptionalValidators = @(
+  @{ Name = 'check-context-currency';           Script = 'check-context-currency.ps1';   Args = @() }
+)
+$AdvisoryValidators = @(
+  @{ Name = 'check-version-references (advisory)'; Script = 'check-version-references.ps1'; Args = @() }
+)
+`;
+
+const CI_FIXTURE = `
+      - name: Lint skills front matter (bash)
+        if: matrix.os == 'ubuntu-latest'
+        run: bash scripts/lint-skills-frontmatter.sh
+      - name: Validate docs frontmatter (bash, enforcing)
+        run: bash scripts/validate-docs-frontmatter.sh --strict
+      - name: Check CONTEXT.md currency (bash)
+        run: bash scripts/check-context-currency.sh
+        continue-on-error: true
+      - name: Check version references (bash)
+        run: bash scripts/check-version-references.sh
+        continue-on-error: true
+      - name: Generate site content
+        run: node scripts/gen-site.mjs
+`;
+
+// A manifest object as js-yaml would parse it.
+const MANIFEST_FIXTURE = [
+  { id: 'lint-skills-frontmatter', bash: { args: [] }, pwsh: { args: [] }, pre_tag: 'required', ci: 'enforcing' },
+  { id: 'validate-docs-frontmatter', bash: { args: ['--strict'] }, pwsh: { args: ['-Strict'] }, pre_tag: 'required', ci: 'enforcing' },
+  { id: 'check-context-currency', bash: { args: [] }, pwsh: { args: [] }, pre_tag: 'optional', ci: 'advisory' },
+  { id: 'check-version-references', bash: { args: [] }, pwsh: { args: [] }, pre_tag: 'advisory', ci: 'advisory' },
+];
+
+// --- parseBashBundle ---
+
+test('parseBashBundle extracts ids per tier from the script path', () => {
+  const b = parseBashBundle(BASH_FIXTURE);
+  assert.deepEqual(b.required.map((e) => e.id), ['lint-skills-frontmatter', 'validate-docs-frontmatter']);
+  assert.deepEqual(b.optional.map((e) => e.id), ['check-context-currency']);
+  assert.deepEqual(b.advisory.map((e) => e.id), ['check-version-references']);
+});
+
+test('parseBashBundle captures trailing flags as args', () => {
+  const b = parseBashBundle(BASH_FIXTURE);
+  const strict = b.required.find((e) => e.id === 'validate-docs-frontmatter');
+  assert.deepEqual(strict.args, ['--strict']);
+  const plain = b.required.find((e) => e.id === 'lint-skills-frontmatter');
+  assert.deepEqual(plain.args, []);
+});
+
+// --- parsePwshBundle ---
+
+test('parsePwshBundle extracts ids per tier from the Script field', () => {
+  const p = parsePwshBundle(PWSH_FIXTURE);
+  assert.deepEqual(p.required.map((e) => e.id), ['lint-skills-frontmatter', 'validate-docs-frontmatter']);
+  assert.deepEqual(p.optional.map((e) => e.id), ['check-context-currency']);
+  assert.deepEqual(p.advisory.map((e) => e.id), ['check-version-references']);
+});
+
+test('parsePwshBundle captures the PowerShell Args array', () => {
+  const p = parsePwshBundle(PWSH_FIXTURE);
+  const strict = p.required.find((e) => e.id === 'validate-docs-frontmatter');
+  assert.deepEqual(strict.args, ['-Strict']);
+});
+
+// --- parseCiWorkflow ---
+
+test('parseCiWorkflow lists shell validators and ignores node steps', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  const ids = ci.map((e) => e.id).sort();
+  assert.deepEqual(ids, [
+    'check-context-currency',
+    'check-version-references',
+    'lint-skills-frontmatter',
+    'validate-docs-frontmatter',
+  ]);
+});
+
+test('parseCiWorkflow marks continue-on-error steps as advisory', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  assert.equal(ci.find((e) => e.id === 'check-context-currency').enforcing, false);
+  assert.equal(ci.find((e) => e.id === 'lint-skills-frontmatter').enforcing, true);
+});
+
+// --- computeParity: the referee verdict ---
+
+test('computeParity returns no findings when all three inventories match the manifest', () => {
+  const findings = computeParity({
+    manifest: MANIFEST_FIXTURE,
+    bash: parseBashBundle(BASH_FIXTURE),
+    pwsh: parsePwshBundle(PWSH_FIXTURE),
+    ci: parseCiWorkflow(CI_FIXTURE),
+  });
+  assert.deepEqual(findings, []);
+});
+
+test('computeParity flags a manifest required validator missing from the bash bundle', () => {
+  const bash = parseBashBundle(BASH_FIXTURE);
+  bash.required = bash.required.filter((e) => e.id !== 'validate-docs-frontmatter');
+  const findings = computeParity({
+    manifest: MANIFEST_FIXTURE,
+    bash,
+    pwsh: parsePwshBundle(PWSH_FIXTURE),
+    ci: parseCiWorkflow(CI_FIXTURE),
+  });
+  assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /bash/.test(f)));
+});
+
+test('computeParity flags a CI shell validator absent from the manifest', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  ci.push({ id: 'rogue-validator', enforcing: true });
+  const findings = computeParity({
+    manifest: MANIFEST_FIXTURE,
+    bash: parseBashBundle(BASH_FIXTURE),
+    pwsh: parsePwshBundle(PWSH_FIXTURE),
+    ci,
+  });
+  assert.ok(findings.some((f) => /rogue-validator/.test(f) && /manifest/i.test(f)));
+});
+
+test('computeParity flags a flag/arg drift between a bundle and the manifest', () => {
+  const bash = parseBashBundle(BASH_FIXTURE);
+  bash.required.find((e) => e.id === 'validate-docs-frontmatter').args = []; // dropped --strict
+  const findings = computeParity({
+    manifest: MANIFEST_FIXTURE,
+    bash,
+    pwsh: parsePwshBundle(PWSH_FIXTURE),
+    ci: parseCiWorkflow(CI_FIXTURE),
+  });
+  assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /arg/i.test(f)));
+});
+
+test('computeParity flags a CI enforcing-level mismatch against the manifest', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  ci.find((e) => e.id === 'check-context-currency').enforcing = true; // manifest says advisory
+  const findings = computeParity({
+    manifest: MANIFEST_FIXTURE,
+    bash: parseBashBundle(BASH_FIXTURE),
+    pwsh: parsePwshBundle(PWSH_FIXTURE),
+    ci,
+  });
+  assert.ok(findings.some((f) => /check-context-currency/.test(f) && /enforc/i.test(f)));
+});

--- a/scripts/pre-tag-validate.ps1
+++ b/scripts/pre-tag-validate.ps1
@@ -20,6 +20,8 @@ $Root = Split-Path -Parent $ScriptDir
 # referenced two retired validators, check-internal-link-validity and
 # check-generated-content-untouched, that no longer exist, and omitted
 # check-skill-sample-coverage that bash and CI both enforce).
+# Source of truth: scripts/validation-manifest.yaml; scripts/check-validator-parity.mjs
+# (CI) fails on any drift between this list, pre-tag-validate.sh, the manifest, and CI.
 $Validators = @(
   @{ Name = 'lint-skills-frontmatter';                       Script = 'lint-skills-frontmatter.ps1';                       Args = @() }
   @{ Name = 'validate-agents-md';                            Script = 'validate-agents-md.ps1';                            Args = @() }
@@ -35,6 +37,8 @@ $Validators = @(
   @{ Name = 'validate-version-consistency';                  Script = 'validate-version-consistency.ps1';                  Args = @() }
   @{ Name = 'validate-codex-manifest';                       Script = 'validate-codex-manifest.ps1';                       Args = @() }
   @{ Name = 'check-skill-sample-coverage';                   Script = 'check-skill-sample-coverage.ps1';                   Args = @() }
+  @{ Name = 'validate-skill-family-registration';            Script = 'validate-skill-family-registration.ps1';            Args = @() }
+  @{ Name = 'validate-plugin-install';                       Script = 'validate-plugin-install.ps1';                       Args = @() }
 )
 
 $OptionalValidators = @(

--- a/scripts/pre-tag-validate.sh
+++ b/scripts/pre-tag-validate.sh
@@ -47,6 +47,8 @@ fi
 
 # Truly-enforcing validator inventory. Update when adding new enforcing validators.
 # Each entry is "<display name>|<command>".
+# Single source of truth: scripts/validation-manifest.yaml. scripts/check-validator-parity.mjs
+# (run in CI) fails if this list drifts from the manifest or from pre-tag-validate.ps1.
 VALIDATORS=(
   "lint-skills-frontmatter|bash $ROOT/scripts/lint-skills-frontmatter.sh"
   "validate-agents-md|bash $ROOT/scripts/validate-agents-md.sh"
@@ -62,6 +64,8 @@ VALIDATORS=(
   "validate-version-consistency|bash $ROOT/scripts/validate-version-consistency.sh"
   "validate-codex-manifest|bash $ROOT/scripts/validate-codex-manifest.sh"
   "check-skill-sample-coverage|bash $ROOT/scripts/check-skill-sample-coverage.sh"
+  "validate-skill-family-registration|bash $ROOT/scripts/validate-skill-family-registration.sh"
+  "validate-plugin-install|bash $ROOT/scripts/validate-plugin-install.sh"
 )
 
 # v2.15.1 additions (landing-page + generator coverage + AGENTS.md command-table sync).

--- a/scripts/validation-manifest.yaml
+++ b/scripts/validation-manifest.yaml
@@ -1,0 +1,173 @@
+# validation-manifest.yaml - the single source of truth for the release-gate
+# SHELL validator inventory (audit Spec A, P0-02).
+#
+# WHY: three inventories must agree about which shell validators run and how:
+#   - scripts/pre-tag-validate.sh   (bash local pre-tag bundle)
+#   - scripts/pre-tag-validate.ps1  (PowerShell local pre-tag bundle)
+#   - .github/workflows/validation.yml  (CI)
+# They drifted before (P0-01, P0-02). This file declares each shell validator
+# ONCE; scripts/check-validator-parity.mjs (run in CI) FAILS the build if any of
+# the three inventories drifts from it. So bash and pwsh can no longer list
+# different sets, and CI cannot add or drop a shell validator without updating
+# this file.
+#
+# SCOPE: shell validators only (scripts/*.sh + scripts/*.ps1). The two local
+# bundles are the cross-platform, dual-maintained surface where drift bit us.
+# Node (.mjs) checks (gen-resource-index --check, check-frontmatter-yaml,
+# check-rendered-links, check-route-parity, check-root-doc-links, verify-edit-links),
+# the Astro site build, and the unit-test steps run ONCE cross-platform in CI with
+# no two-shell duplication, so they are out of this manifest's parity remit by
+# design. They live in validation.yml only.
+#
+# FIELDS per entry:
+#   id       stable validator name (the scripts/<id>.sh + scripts/<id>.ps1 pair)
+#   pre_tag  local-bundle tier: required | optional | advisory. OMITTED for
+#            validators that run in CI only (not in the local pre-tag bundle).
+#              required = always run, must pass (blocks the bundle)
+#              optional = run if the script is present (graceful degradation for
+#                         older checkouts), then must pass
+#              advisory = run for visibility, never blocks
+#   ci       CI level: enforcing | advisory (advisory == continue-on-error in
+#            validation.yml). OMIT if the validator is not run in CI.
+#   bash     { script, args } as invoked by bash (flags use the --flag form)
+#   pwsh     { script, args } as invoked by pwsh (flags use the -Flag form)
+#
+# When you add, retire, or re-flag a shell validator, edit THIS file and the
+# matching inventory; the parity referee proves they agree.
+
+# === Required: local pre-tag (blocking) + enforcing in CI ===
+- id: lint-skills-frontmatter
+  pre_tag: required
+  ci: enforcing
+  bash: { script: lint-skills-frontmatter.sh, args: [] }
+  pwsh: { script: lint-skills-frontmatter.ps1, args: [] }
+- id: validate-agents-md
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-agents-md.sh, args: [] }
+  pwsh: { script: validate-agents-md.ps1, args: [] }
+- id: validate-commands
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-commands.sh, args: [] }
+  pwsh: { script: validate-commands.ps1, args: [] }
+- id: validate-meeting-skills-family
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-meeting-skills-family.sh, args: [] }
+  pwsh: { script: validate-meeting-skills-family.ps1, args: [] }
+- id: validate-foundation-sprint-skills-family
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-foundation-sprint-skills-family.sh, args: ['--strict'] }
+  pwsh: { script: validate-foundation-sprint-skills-family.ps1, args: ['-Strict'] }
+- id: validate-design-sprint-skills-family
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-design-sprint-skills-family.sh, args: ['--strict'] }
+  pwsh: { script: validate-design-sprint-skills-family.ps1, args: ['-Strict'] }
+- id: validate-docs-frontmatter
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-docs-frontmatter.sh, args: ['--strict'] }
+  pwsh: { script: validate-docs-frontmatter.ps1, args: ['-Strict'] }
+- id: check-no-body-h1
+  pre_tag: required
+  ci: enforcing
+  bash: { script: check-no-body-h1.sh, args: ['--strict'] }
+  pwsh: { script: check-no-body-h1.ps1, args: ['-Strict'] }
+- id: check-count-consistency
+  pre_tag: required
+  ci: enforcing
+  bash: { script: check-count-consistency.sh, args: [] }
+  pwsh: { script: check-count-consistency.ps1, args: [] }
+- id: check-skill-cross-references
+  pre_tag: required
+  ci: enforcing
+  bash: { script: check-skill-cross-references.sh, args: [] }
+  pwsh: { script: check-skill-cross-references.ps1, args: [] }
+- id: validate-script-docs
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-script-docs.sh, args: [] }
+  pwsh: { script: validate-script-docs.ps1, args: [] }
+- id: validate-version-consistency
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-version-consistency.sh, args: [] }
+  pwsh: { script: validate-version-consistency.ps1, args: [] }
+- id: validate-codex-manifest
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-codex-manifest.sh, args: [] }
+  pwsh: { script: validate-codex-manifest.ps1, args: [] }
+- id: check-skill-sample-coverage
+  pre_tag: required
+  ci: enforcing
+  bash: { script: check-skill-sample-coverage.sh, args: [] }
+  pwsh: { script: check-skill-sample-coverage.ps1, args: [] }
+# Added in the Spec A reconciliation: enforcing in CI, previously absent from both
+# local bundles (the live drift P0-02 warned about, surfaced after #174).
+- id: validate-skill-family-registration
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-skill-family-registration.sh, args: [] }
+  pwsh: { script: validate-skill-family-registration.ps1, args: [] }
+- id: validate-plugin-install
+  pre_tag: required
+  ci: enforcing
+  bash: { script: validate-plugin-install.sh, args: [] }
+  pwsh: { script: validate-plugin-install.ps1, args: [] }
+
+# === Optional: local pre-tag (graceful degradation) ===
+- id: check-landing-page-counts
+  pre_tag: optional
+  ci: enforcing
+  bash: { script: check-landing-page-counts.sh, args: ['--strict'] }
+  pwsh: { script: check-landing-page-counts.ps1, args: ['-Strict'] }
+- id: check-workflow-generator-coverage
+  pre_tag: optional
+  ci: enforcing
+  bash: { script: check-workflow-generator-coverage.sh, args: [] }
+  pwsh: { script: check-workflow-generator-coverage.ps1, args: [] }
+- id: check-agents-md-command-sync
+  pre_tag: optional
+  ci: enforcing
+  bash: { script: check-agents-md-command-sync.sh, args: [] }
+  pwsh: { script: check-agents-md-command-sync.ps1, args: [] }
+# Optional locally but advisory (continue-on-error) in CI: a pre-existing
+# asymmetry, faithfully recorded rather than silently "fixed" here.
+- id: check-context-currency
+  pre_tag: optional
+  ci: advisory
+  bash: { script: check-context-currency.sh, args: [] }
+  pwsh: { script: check-context-currency.ps1, args: [] }
+
+# === Advisory: local pre-tag (never blocks) + advisory in CI ===
+- id: check-version-references
+  pre_tag: advisory
+  ci: advisory
+  bash: { script: check-version-references.sh, args: [] }
+  pwsh: { script: check-version-references.ps1, args: [] }
+
+# === CI-only: advisory in CI, intentionally NOT in the local pre-tag bundle ===
+- id: check-mcp-impact
+  ci: advisory
+  bash: { script: check-mcp-impact.sh, args: [] }
+  pwsh: { script: check-mcp-impact.ps1, args: [] }
+- id: validate-skill-history
+  ci: advisory
+  bash: { script: validate-skill-history.sh, args: [] }
+  pwsh: { script: validate-skill-history.ps1, args: [] }
+- id: validate-skills-manifest
+  ci: advisory
+  bash: { script: validate-skills-manifest.sh, args: [] }
+  pwsh: { script: validate-skills-manifest.ps1, args: [] }
+- id: validate-gitignore-pm-skills
+  ci: advisory
+  bash: { script: validate-gitignore-pm-skills.sh, args: [] }
+  pwsh: { script: validate-gitignore-pm-skills.ps1, args: [] }
+- id: check-workflow-coverage
+  ci: advisory
+  bash: { script: check-workflow-coverage.sh, args: [] }
+  pwsh: { script: check-workflow-coverage.ps1, args: [] }


### PR DESCRIPTION
## What

Closes the last open follow-up from the 2026-06-06 Codex audit: **Spec A** (P0-02) - a single source of truth for the release-gate shell-validator inventory.

## Why

The release gate had three hand-maintained shell-validator inventories: `scripts/pre-tag-validate.sh`, `scripts/pre-tag-validate.ps1`, and `.github/workflows/validation.yml`. They drifted before (P0-01/P0-02) and were **still drifting**: `validate-skill-family-registration` and `validate-plugin-install` were enforcing in CI but absent from both local bundles, so a local "ALL CHECKS PASSED" could still meet a red CI leg on a release PR.

## What changed

- **`scripts/validation-manifest.yaml`** - the single source of truth. Each shell validator is declared once with its local pre-tag tier, CI level, and per-shell flags.
- **`scripts/check-validator-parity.mjs`** (+ 11 unit tests) - the referee. Fails the build if any of the three inventories drifts from the manifest (tier-set, flag, CI presence, or enforcing-level). Wired enforcing in CI on both OS legs.
- Reconciled the two drifted validators into the required tier of both bundles.
- Docs: CHANGELOG `[Unreleased]`, an `_unreleased/` plan doc, and the audit follow-up tracking flipped to done.

## Approach

Drift-gate (referee), not codegen: keeps the hand-tuned shell runners (color, `--skip`, advisory verdict extraction) and matches the repo's existing drift-gate idiom (`check-route-parity.mjs`, `gen-resource-index.mjs --check`). Manifest scope is shell validators only; Node (`.mjs`) checks, the site build, and unit tests stay in `validation.yml` because they run once cross-platform with no two-shell duplication.

## Acceptance (all met locally)

- [x] PowerShell pre-tag passes (`ALL CHECKS PASSED`, exit 0; both new validators PASS)
- [x] Bash pre-tag passes (`ALL CHECKS PASSED`, exit 0)
- [x] Both bundles list the same required validator IDs (referee-enforced)
- [x] CI cannot add or drop a shell validator without updating the manifest

## Test plan

- `node --test scripts/check-validator-parity.test.mjs` - 11/11 pass
- `node scripts/check-validator-parity.mjs` - PASS (and demonstrated catching the live drift before reconciliation)
- Both full pre-tag bundles run green on Windows + Git Bash
- CI runs the referee on both ubuntu-latest and windows-latest legs
