### PR TITLE
docs(release): bank #178 + pre-stage v2.25.2; reconcile stale _unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/validation-manifest.yaml`: a single source of truth for the release-gate shell-validator inventory. Declares every `scripts/*.sh` + `*.ps1` validator once with its local pre-tag tier, CI level, and per-shell flags.
 - `scripts/check-validator-parity.mjs` (+ unit tests), wired enforcing in CI on both OS legs: a referee that fails the build if the bash bundle (`scripts/pre-tag-validate.sh`), the PowerShell bundle (`scripts/pre-tag-validate.ps1`), or `.github/workflows/validation.yml` drifts from the manifest. The two local pre-tag bundles can no longer list different validator sets, and CI cannot add or drop a shell validator without updating the manifest. Pure Node builtins plus `js-yaml` (the existing root tooling dependency).
 
+### Changed
+
+- `scripts/check-root-doc-links.mjs` now also scans the source surfaces (`skills/**`, `agents/**`, `_workflows/**`, `commands/**`; 245 files) in addition to repo-root markdown, with a documented Pattern S relocation alias (`docs/<tail>` resolves to `site/src/content/docs/<tail>`) and a brace-placeholder skip for template tokens. Closes the class where source links to the retired `docs/reference/...` paths rotted after the Pattern S relocation while staying invisible to GitHub source readers.
+
 ### Fixed
 
 - Reconciled live drift between the local pre-tag bundles and CI: `validate-skill-family-registration` and `validate-plugin-install` were enforcing in `.github/workflows/validation.yml` but absent from both `scripts/pre-tag-validate.sh` and `scripts/pre-tag-validate.ps1`, so a local "ALL CHECKS PASSED" could still meet a red CI leg on a release PR. Both validators are now in the required tier of both bundles, and the new parity referee prevents the gap from recurring.
+- `scripts/validate-skill-history.{sh,ps1}` now read the nested `metadata.version` (with a top-level fallback), so per-skill `HISTORY.md` validation runs against the current skill-frontmatter shape instead of silently passing.
+- Repointed the release conductor and auditor agents and the release runbook from the retired `docs/{contributing,reference,releases}/` paths to their live `site/src/content/docs/...` locations, resolving the runbook-path drift noted while shipping v2.25.1.
 
 ## [2.25.1] - 2026-06-06
 

--- a/docs/internal/release-plans/_unreleased/changelog-em-dash-sweep/plan_changelog-em-dash-sweep.md
+++ b/docs/internal/release-plans/_unreleased/changelog-em-dash-sweep/plan_changelog-em-dash-sweep.md
@@ -1,6 +1,6 @@
 # Plan: CHANGELOG (and doc-body) em-dash-sweep scar cleanup
 
-Status: deferred / backlog (not started)
+Status: PARTIALLY SHIPPED in v2.25.1. The CHANGELOG, site-doc-body, and internal-prose safe-subset sweeps shipped (PRs #168/#169/#170; advisory guard `check-emdash-scars.mjs` in #171). The remainder (roughly 120 internal heading scars + 295 in-fence cases needing per-case judgment) is deferred/optional. See the v2.25.1 CHANGELOG and `docs/internal/release-plans/v2.25.1/plan_v2.25.1.md`.
 Tracking issue: #167 (canonical backlog entry; this doc is the scope artifact)
 Date: 2026-06-05
 Trigger: surfaced during the resource-index work (PRs #164/#165)

--- a/docs/internal/release-plans/_unreleased/resource-index/plan_resource-index.md
+++ b/docs/internal/release-plans/_unreleased/resource-index/plan_resource-index.md
@@ -1,5 +1,7 @@
 # Resource Index Implementation Plan
 
+**Status:** SHIPPED in v2.25.1 (PR #164). Retained for historical reference; see `docs/internal/release-plans/v2.25.1/plan_v2.25.1.md` and the `[2.25.1]` CHANGELOG section.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a generated, CI-gated `docs/RESOURCES.md` catalog that links every project resource to both its published page and its source-of-truth file in the repo, plus a hand-authored `docs/README.md` front door, so the docs are browsable on GitHub at a stable path and can never silently go stale.

--- a/docs/internal/release-plans/v2.25.2/plan_v2.25.2.md
+++ b/docs/internal/release-plans/v2.25.2/plan_v2.25.2.md
@@ -1,0 +1,51 @@
+# v2.25.2 Release Plan: Maintenance patch (bank post-v2.25.1 accumulation)
+
+**Status:** PLANNED (pre-staged 2026-06-09; NOT yet cut). Banked work is merged and CI-green on `main`; this plan is ready to run through the release runbook on command. Cut trigger: when more maintenance accumulates, or on request.
+**Owner:** Maintainers
+**Type:** **PATCH** (maintenance only: no consumable-surface change; catalog stays 30 phase + 9 foundation + 11 utility + 15 tool = 65 skills and 5 sub-agents; the sole version bump banks accumulated maintenance, not a capability delta).
+**Theme:** Bank the maintenance accumulated since v2.25.1 (the final Codex-audit follow-ups) under one versioned GitHub Release. No new skills, no behavior change.
+**Created:** 2026-06-09
+**Updated:** 2026-06-09
+
+---
+
+## Where we are
+
+Since `v2.25.1` (`2b5044a`, 2026-06-06) `main` has accumulated four commits, all merged and CI-green, deliberately shipped untagged per the repo's "SemVer tracks compatibility, not significance" rule (maintenance is banked, not tagged per change). Two are user/contributor-facing tooling changes (already drafted in CHANGELOG `[Unreleased]`); two are internal-docs-only and carry no CHANGELOG entry by convention.
+
+This batch closes the **last of the 2026-06-06 Codex audit follow-ups** (Spec A / P0-02). With it, every audit finding (P0-01, P0-02, P1-01..P1-03) is resolved.
+
+When cut, G2 (via `pm-changelog-curator`) confirms `[Unreleased]` is complete, then moves the whole body to a `## [2.25.2] - <date>` section and opens a fresh empty `[Unreleased]`.
+
+## Scope - what v2.25.2 banks (commits since v2.25.1)
+
+| Area | Commit | Supporting spec | In `[Unreleased]`? |
+|---|---|---|---|
+| Validator-inventory manifest + parity referee (audit Spec A / P0-02) | `faf1ec3` (#180) | `docs/internal/release-plans/_unreleased/validator-manifest.md` | Yes (Added + Changed + Fixed) |
+| Codex audit P1 follow-ups: `check-root-doc-links` source-surface scan (P1-01), `validate-skill-history` reads `metadata.version` (P1-03), agent + runbook path repoints (P1-02) | `727bbbc` (#178) | `docs/internal/audit/2026-06-06_codex_review.md` (follow-up list) | Yes (Changed + Fixed) |
+| Codex audit now tracked: inline `🔵 CLAUDE` annotations + companion review doc | `20af801` (#177) | the audit + review docs themselves | n/a (internal docs only) |
+| v2.25.1 post-tag hygiene: plan + CONTEXT flips to SHIPPED | `50f564d` (#176) | `docs/internal/release-plans/v2.25.1/plan_v2.25.1.md` | n/a (internal docs only) |
+
+## Release surfaces (G2)
+
+- `CHANGELOG.md`: confirm `[Unreleased]` complete, then move to `## [2.25.2] - <date>`; add a fresh empty `[Unreleased]`.
+- `site/src/content/docs/changelog.md`: add a curated one-paragraph `[2.25.2]` entry (a summary that links out, NOT a 1:1 mirror).
+- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`: bump `version` 2.25.1 -> 2.25.2.
+- `README.md`: version badge + What's New + Current version row.
+- `_agent-context/claude/CONTEXT.md` + `_agent-context/codex/CONTEXT.md`: currency markers to v2.25.2 (gated by `check-context-currency`).
+- `site/src/content/docs/releases/Release_v2.25.2.md` (site path post-Pattern-S) + the releases `index.md`.
+- This plan status -> SHIPPED at G4; move the fed `_unreleased/` specs into this folder.
+
+## Gate ledger (to run at cut time)
+
+- [ ] G0 Pre-tag readiness (the pre-tag bundle is now manifest-checked by `check-validator-parity.mjs`; counters unchanged at 65/5; governance audit 0 P0)
+- [ ] G1 Adversarial review attestation (maintenance patch of already-merged, already-CI-green work; the Spec A change carried its own 11-test referee + green PR #180)
+- [ ] G2 Version bump + CHANGELOG move (curator; leak check; version-consistency + context-currency PASS)
+- [ ] G2.5 Commit release-prep + PR + CI green both OS legs + CodeQL; squash-merge to main
+- [ ] G3 Annotated tag `v2.25.2` on the post-squash-merge main SHA + push
+- [ ] G4 Post-tag hygiene (GitHub Release Latest; `agent-plugins` registry re-pin; Pages deploy; flip this plan to SHIPPED)
+
+## Notes
+
+- The runbook-path drift the v2.25.1 plan flagged for "later" (conductor + auditor + runbook citing the pre-Pattern-S `docs/{contributing,releases}/` paths) is **resolved** in this batch by #178 (P1-02). The release runbook the conductor reads now points at the live `site/src/content/docs/...` paths.
+- This is a pre-stage: do not bump versions or tag until the cut is requested. Keep banking additional maintenance into `[Unreleased]` until then; add rows here as commits land.


### PR DESCRIPTION
## What

Banking hygiene for the four maintenance commits accumulated since v2.25.1 (#176-#180), ahead of a future **v2.25.2** PATCH cut. Docs-only; no version bump, no tag.

## Why

#180 (Spec A) closed the last 2026-06-06 Codex audit follow-up, but #178 had never been drafted into the CHANGELOG, and `_unreleased/` still held v2.25.1 leftovers (one marked "deferred / not started" for work that shipped). This makes the next cut clean.

## Changes

- **CHANGELOG `[Unreleased]`**: added the #178 audit P1 follow-ups (check-root-doc-links source-surface scan; validate-skill-history `metadata.version`; agent/runbook path repoints). #180 was already drafted.
- **`docs/internal/release-plans/v2.25.2/plan_v2.25.2.md`**: pre-staged PATCH plan (`Status: PLANNED`) with a scope table for #176-#180 and supporting-spec links; ready for the release runbook on command.
- **Reconciled stale `_unreleased/` statuses** in place (no moves: `scripts/gen-resource-index.mjs` references the path): `changelog-em-dash-sweep` to partially-shipped + deferred remainder; `resource-index` to shipped.

## Verification

- Pre-tag bundle `ALL CHECKS PASSED`; `check-root-doc-links` PASS; `check-validator-parity` PASS (local).