### PR TITLE
fix(ci): resolve Codex adversarial-review findings (per-leg CI parity, multi-backtick scar guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `scripts/validation-manifest.yaml`: a single source of truth for the release-gate shell-validator inventory. Declares every `scripts/*.sh` + `*.ps1` validator once with its local pre-tag tier, CI level, and per-shell flags.
-- `scripts/check-validator-parity.mjs` (+ unit tests), wired enforcing in CI on both OS legs: a referee that fails the build if the bash bundle (`scripts/pre-tag-validate.sh`), the PowerShell bundle (`scripts/pre-tag-validate.ps1`), or `.github/workflows/validation.yml` drifts from the manifest. The two local pre-tag bundles can no longer list different validator sets, and CI cannot add or drop a shell validator without updating the manifest. Pure Node builtins plus `js-yaml` (the existing root tooling dependency).
+- `scripts/check-validator-parity.mjs` (+ unit tests), wired enforcing in CI on both OS legs: a referee that fails the build if the bash bundle (`scripts/pre-tag-validate.sh`), the PowerShell bundle (`scripts/pre-tag-validate.ps1`), or `.github/workflows/validation.yml` drifts from the manifest. The two local pre-tag bundles can no longer list different validator sets, and CI cannot add, drop, re-flag, or change the per-OS enforcement of a shell validator without updating the manifest (the referee compares each OS leg's args and enforcing level, not just presence). Pure Node builtins plus `js-yaml` (the existing root tooling dependency).
 
 ### Changed
 
 - `scripts/check-root-doc-links.mjs` now also scans the source surfaces (`skills/**`, `agents/**`, `_workflows/**`, `commands/**`; 245 files) in addition to repo-root markdown, with a documented Pattern S relocation alias (`docs/<tail>` resolves to `site/src/content/docs/<tail>`) and a brace-placeholder skip for template tokens. Closes the class where source links to the retired `docs/reference/...` paths rotted after the Pattern S relocation while staying invisible to GitHub source readers.
-- `scripts/check-emdash-scars.mjs` is now **enforcing** in CI (previously advisory) and skips inline-code spans in addition to fenced blocks, so prose that quotes the ` . ` scar as a literal example (as the release notes do) is no longer flagged. The user-facing prose corpus is clean, so any newly introduced spaced-period scar now fails the build.
+- `scripts/check-emdash-scars.mjs` is now **enforcing** in CI (previously advisory) and skips inline-code spans (including multi-backtick spans) in addition to fenced blocks, so prose that quotes the ` . ` scar as a literal example (as the release notes do) is no longer flagged. The user-facing prose corpus is clean, so any newly introduced spaced-period scar now fails the build.
 
 ### Fixed
 

--- a/docs/internal/release-plans/v2.25.2/plan_v2.25.2.md
+++ b/docs/internal/release-plans/v2.25.2/plan_v2.25.2.md
@@ -39,8 +39,8 @@ When cut, G2 (via `pm-changelog-curator`) confirms `[Unreleased]` is complete, t
 
 ## Gate ledger (to run at cut time)
 
-- [ ] G0 Pre-tag readiness (the pre-tag bundle is now manifest-checked by `check-validator-parity.mjs`; counters unchanged at 65/5; governance audit 0 P0)
-- [ ] G1 Adversarial review attestation (maintenance patch of already-merged, already-CI-green work; the Spec A change carried its own 11-test referee + green PR #180)
+- [ ] G0 Pre-tag readiness (the pre-tag bundle runs the enforcing validators; bash/pwsh/CI inventory parity is checked by `check-validator-parity.mjs` in CI, NOT by the local bundle, so confirm it from the validation workflow on the release PR; counters unchanged at 65/5; governance audit 0 P0)
+- [ ] G1 Adversarial review attestation (a Codex adversarial review of the `v2.25.1..HEAD` diff was run 2026-06-10 via `codex:adversarial-review`; it found 1 P1 + 2 P2, all resolved before cut: the parity referee now does per-leg CI checks (args + per-OS enforcement), the scar guard handles multi-backtick spans, and this G0 wording was corrected; the referee + scar guard carry 15 + 10 unit tests)
 - [ ] G2 Version bump + CHANGELOG move (curator; leak check; version-consistency + context-currency PASS)
 - [ ] G2.5 Commit release-prep + PR + CI green both OS legs + CodeQL; squash-merge to main
 - [ ] G3 Annotated tag `v2.25.2` on the post-squash-merge main SHA + push

--- a/scripts/check-emdash-scars.mjs
+++ b/scripts/check-emdash-scars.mjs
@@ -48,10 +48,12 @@ export function findScars(text) {
     if (inFence) continue;
     // Replace inline-code spans with a single non-space placeholder before
     // testing: release notes legitimately quote the scar itself (the ` . ` token)
-    // and code spans can hold a real spaced period. The placeholder (not empty
-    // string) preserves boundaries, so a normal `code`. sentence period does NOT
-    // collapse into a phantom " . "; a real scar OUTSIDE the span still survives.
-    const stripped = line.replace(/`[^`]*`/g, 'x');
+    // and code spans can hold a real spaced period. `(`+)(.*?)\1` matches a
+    // CommonMark backtick run of any length N closed by the same run, so multi-
+    // backtick spans (`` . ``) are handled too. The placeholder (not empty string)
+    // preserves boundaries, so a normal `code`. sentence period does NOT collapse
+    // into a phantom " . "; a real scar OUTSIDE the span still survives.
+    const stripped = line.replace(/(`+)(.*?)\1/g, 'x');
     if (/ \. /.test(stripped)) hits.push({ line: i + 1, text: line.trim() });
   }
   return hits;

--- a/scripts/check-emdash-scars.test.mjs
+++ b/scripts/check-emdash-scars.test.mjs
@@ -43,3 +43,14 @@ test('findScars does not manufacture a scar from a code span followed by a sente
   // `code`. Next must NOT collapse into a phantom " . " when the span is stripped.
   assert.equal(findScars('read by the `docsLoader()`. Repo-root is governance docs').length, 0);
 });
+
+test('findScars ignores a spaced period inside a multi-backtick code span', () => {
+  // CommonMark allows N-backtick spans (used when the content itself holds backticks).
+  // A double-backtick span quoting the scar must not be flagged now that the guard enforces.
+  assert.equal(findScars('the `` . `` token is a literal example').length, 0);
+});
+
+test('findScars still flags a real scar outside a multi-backtick span', () => {
+  const hits = findScars('see ``a `nested` b`` then x . y');
+  assert.equal(hits.length, 1);
+});

--- a/scripts/check-validator-parity.mjs
+++ b/scripts/check-validator-parity.mjs
@@ -102,27 +102,31 @@ export function parsePwshBundle(text) {
   };
 }
 
-// Split validation.yml into `- name:` step blocks. A validator is advisory in CI
-// when its step carries `continue-on-error: true`. A validator runs on two legs
-// (bash + pwsh) in separate blocks; it is treated as enforcing if any leg enforces.
+// Split validation.yml into `- name:` step blocks and return ONE record per OS leg
+// (a validator runs as a bash step on ubuntu and a pwsh step on windows). Each leg
+// captures its shell, its args, and whether it enforces (a step carrying
+// `continue-on-error: true` is advisory). Per-leg granularity is required so the
+// referee catches CI drift the bundles cannot have: a flag dropped from one leg, or
+// one OS leg silently made advisory while the other still enforces.
 export function parseCiWorkflow(text) {
   const blocks = text.split(/\n[ \t]*- name:/).slice(1);
-  const byId = new Map();
+  const legs = [];
   for (const block of blocks) {
     const enforcing = !/continue-on-error:\s*true/.test(block);
     for (const raw of block.split('\n')) {
       const line = raw.trim();
       if (line.startsWith('#')) continue; // skip comments referencing script paths
-      const re = /scripts\/([\w-]+)\.(?:sh|ps1)\b/g;
-      let m;
-      while ((m = re.exec(line))) {
-        const id = m[1];
-        const prev = byId.get(id);
-        byId.set(id, { id, enforcing: (prev ? prev.enforcing : false) || enforcing });
-      }
+      let m = line.match(/\bbash\s+scripts\/([\w-]+)\.sh\b(.*)$/);
+      if (m) { legs.push({ id: m[1], shell: 'bash', args: tokenizeArgs(m[2]), enforcing }); continue; }
+      m = line.match(/\bpwsh\s+-File\s+scripts\/([\w-]+)\.ps1\b(.*)$/);
+      if (m) { legs.push({ id: m[1], shell: 'pwsh', args: tokenizeArgs(m[2]), enforcing }); }
     }
   }
-  return [...byId.values()];
+  return legs;
+}
+
+function tokenizeArgs(s) {
+  return s.trim().split(/\s+/).filter(Boolean);
 }
 
 // --- the verdict ---------------------------------------------------------
@@ -166,22 +170,34 @@ export function computeParity({ manifest, bash, pwsh, ci }) {
     }
   }
 
-  const ciById = new Map(ci.map((e) => [e.id, e]));
+  // CI: per-leg parity. Each manifest entry with a ci level must have BOTH OS legs in
+  // validation.yml, and each leg's args + enforcing must match the manifest (the bash
+  // leg vs manifest.bash.args, the pwsh leg vs manifest.pwsh.args). This closes the
+  // gap where CI could drop a flag from one leg, or make a single OS leg advisory,
+  // and still pass.
+  const ciByKey = new Map(ci.map((l) => [`${l.id}:${l.shell}`, l]));
   for (const e of manifest) {
     if (!e.ci) continue;
-    if (!ciById.has(e.id)) {
-      findings.push(`manifest declares ci: ${e.ci} for "${e.id}" but no matching shell step exists in validation.yml`);
-      continue;
-    }
-    const actual = ciById.get(e.id).enforcing ? 'enforcing' : 'advisory';
-    if (actual !== e.ci) {
-      findings.push(`"${e.id}" is ${actual} in validation.yml but the manifest declares ci: ${e.ci} (enforcing-level drift)`);
+    for (const shell of ['bash', 'pwsh']) {
+      const l = ciByKey.get(`${e.id}:${shell}`);
+      if (!l) {
+        findings.push(`manifest declares ci: ${e.ci} for "${e.id}" but no ${shell} step exists in validation.yml`);
+        continue;
+      }
+      const expectedArgs = (e[shell] && e[shell].args) || [];
+      if (JSON.stringify(expectedArgs) !== JSON.stringify(l.args)) {
+        findings.push(`validation.yml ${shell} step for "${e.id}" runs args [${l.args.join(' ')}] but the manifest declares [${expectedArgs.join(' ')}] (CI arg drift)`);
+      }
+      const actual = l.enforcing ? 'enforcing' : 'advisory';
+      if (actual !== e.ci) {
+        findings.push(`validation.yml ${shell} step for "${e.id}" is ${actual} but the manifest declares ci: ${e.ci} (CI enforcing-level drift)`);
+      }
     }
   }
-  for (const e of ci) {
-    const m = mById.get(e.id);
+  for (const l of ci) {
+    const m = mById.get(l.id);
     if (!m || !m.ci) {
-      findings.push(`validation.yml runs shell validator "${e.id}" but it is not declared (with a ci: level) in the manifest`);
+      findings.push(`validation.yml runs the ${l.shell} shell validator "${l.id}" but it is not declared (with a ci: level) in the manifest`);
     }
   }
 

--- a/scripts/check-validator-parity.test.mjs
+++ b/scripts/check-validator-parity.test.mjs
@@ -42,17 +42,37 @@ $AdvisoryValidators = @(
 )
 `;
 
+// Each shell validator runs as a per-OS leg (bash on ubuntu, pwsh on windows),
+// matching the real validation.yml matrix shape. The referee must compare each leg
+// independently (args + enforcing), so the fixture carries both legs.
 const CI_FIXTURE = `
       - name: Lint skills front matter (bash)
         if: matrix.os == 'ubuntu-latest'
         run: bash scripts/lint-skills-frontmatter.sh
+      - name: Lint skills front matter (pwsh)
+        if: matrix.os == 'windows-latest'
+        run: pwsh -File scripts/lint-skills-frontmatter.ps1
       - name: Validate docs frontmatter (bash, enforcing)
+        if: matrix.os == 'ubuntu-latest'
         run: bash scripts/validate-docs-frontmatter.sh --strict
+      - name: Validate docs frontmatter (pwsh, enforcing)
+        if: matrix.os == 'windows-latest'
+        run: pwsh -File scripts/validate-docs-frontmatter.ps1 -Strict
       - name: Check CONTEXT.md currency (bash)
+        if: matrix.os == 'ubuntu-latest'
         run: bash scripts/check-context-currency.sh
         continue-on-error: true
+      - name: Check CONTEXT.md currency (pwsh)
+        if: matrix.os == 'windows-latest'
+        run: pwsh -File scripts/check-context-currency.ps1
+        continue-on-error: true
       - name: Check version references (bash)
+        if: matrix.os == 'ubuntu-latest'
         run: bash scripts/check-version-references.sh
+        continue-on-error: true
+      - name: Check version references (pwsh)
+        if: matrix.os == 'windows-latest'
+        run: pwsh -File scripts/check-version-references.ps1
         continue-on-error: true
       - name: Generate site content
         run: node scripts/gen-site.mjs
@@ -66,6 +86,8 @@ const MANIFEST_FIXTURE = [
   { id: 'check-version-references', bash: { args: [] }, pwsh: { args: [] }, pre_tag: 'advisory', ci: 'advisory' },
 ];
 
+const leg = (ci, id, shell) => ci.find((l) => l.id === id && l.shell === shell);
+
 // --- parseBashBundle ---
 
 test('parseBashBundle extracts ids per tier from the script path', () => {
@@ -77,10 +99,8 @@ test('parseBashBundle extracts ids per tier from the script path', () => {
 
 test('parseBashBundle captures trailing flags as args', () => {
   const b = parseBashBundle(BASH_FIXTURE);
-  const strict = b.required.find((e) => e.id === 'validate-docs-frontmatter');
-  assert.deepEqual(strict.args, ['--strict']);
-  const plain = b.required.find((e) => e.id === 'lint-skills-frontmatter');
-  assert.deepEqual(plain.args, []);
+  assert.deepEqual(b.required.find((e) => e.id === 'validate-docs-frontmatter').args, ['--strict']);
+  assert.deepEqual(b.required.find((e) => e.id === 'lint-skills-frontmatter').args, []);
 });
 
 // --- parsePwshBundle ---
@@ -94,85 +114,92 @@ test('parsePwshBundle extracts ids per tier from the Script field', () => {
 
 test('parsePwshBundle captures the PowerShell Args array', () => {
   const p = parsePwshBundle(PWSH_FIXTURE);
-  const strict = p.required.find((e) => e.id === 'validate-docs-frontmatter');
-  assert.deepEqual(strict.args, ['-Strict']);
+  assert.deepEqual(p.required.find((e) => e.id === 'validate-docs-frontmatter').args, ['-Strict']);
 });
 
-// --- parseCiWorkflow ---
+// --- parseCiWorkflow (per-leg) ---
 
-test('parseCiWorkflow lists shell validators and ignores node steps', () => {
+test('parseCiWorkflow returns one record per OS leg and ignores node steps', () => {
   const ci = parseCiWorkflow(CI_FIXTURE);
-  const ids = ci.map((e) => e.id).sort();
-  assert.deepEqual(ids, [
-    'check-context-currency',
-    'check-version-references',
-    'lint-skills-frontmatter',
-    'validate-docs-frontmatter',
-  ]);
+  assert.equal(ci.length, 8); // 4 validators x 2 legs; the node step is ignored
+  assert.deepEqual(
+    [...new Set(ci.map((l) => l.id))].sort(),
+    ['check-context-currency', 'check-version-references', 'lint-skills-frontmatter', 'validate-docs-frontmatter']
+  );
 });
 
-test('parseCiWorkflow marks continue-on-error steps as advisory', () => {
+test('parseCiWorkflow captures per-leg args (bash --strict vs pwsh -Strict)', () => {
   const ci = parseCiWorkflow(CI_FIXTURE);
-  assert.equal(ci.find((e) => e.id === 'check-context-currency').enforcing, false);
-  assert.equal(ci.find((e) => e.id === 'lint-skills-frontmatter').enforcing, true);
+  assert.deepEqual(leg(ci, 'validate-docs-frontmatter', 'bash').args, ['--strict']);
+  assert.deepEqual(leg(ci, 'validate-docs-frontmatter', 'pwsh').args, ['-Strict']);
+});
+
+test('parseCiWorkflow marks continue-on-error legs as advisory, per leg', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  assert.equal(leg(ci, 'check-context-currency', 'bash').enforcing, false);
+  assert.equal(leg(ci, 'lint-skills-frontmatter', 'pwsh').enforcing, true);
 });
 
 // --- computeParity: the referee verdict ---
 
+const parityArgs = (overrides = {}) => ({
+  manifest: MANIFEST_FIXTURE,
+  bash: parseBashBundle(BASH_FIXTURE),
+  pwsh: parsePwshBundle(PWSH_FIXTURE),
+  ci: parseCiWorkflow(CI_FIXTURE),
+  ...overrides,
+});
+
 test('computeParity returns no findings when all three inventories match the manifest', () => {
-  const findings = computeParity({
-    manifest: MANIFEST_FIXTURE,
-    bash: parseBashBundle(BASH_FIXTURE),
-    pwsh: parsePwshBundle(PWSH_FIXTURE),
-    ci: parseCiWorkflow(CI_FIXTURE),
-  });
-  assert.deepEqual(findings, []);
+  assert.deepEqual(computeParity(parityArgs()), []);
 });
 
 test('computeParity flags a manifest required validator missing from the bash bundle', () => {
   const bash = parseBashBundle(BASH_FIXTURE);
   bash.required = bash.required.filter((e) => e.id !== 'validate-docs-frontmatter');
-  const findings = computeParity({
-    manifest: MANIFEST_FIXTURE,
-    bash,
-    pwsh: parsePwshBundle(PWSH_FIXTURE),
-    ci: parseCiWorkflow(CI_FIXTURE),
-  });
+  const findings = computeParity(parityArgs({ bash }));
   assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /bash/.test(f)));
 });
 
 test('computeParity flags a CI shell validator absent from the manifest', () => {
   const ci = parseCiWorkflow(CI_FIXTURE);
-  ci.push({ id: 'rogue-validator', enforcing: true });
-  const findings = computeParity({
-    manifest: MANIFEST_FIXTURE,
-    bash: parseBashBundle(BASH_FIXTURE),
-    pwsh: parsePwshBundle(PWSH_FIXTURE),
-    ci,
-  });
+  ci.push({ id: 'rogue-validator', shell: 'bash', args: [], enforcing: true });
+  const findings = computeParity(parityArgs({ ci }));
   assert.ok(findings.some((f) => /rogue-validator/.test(f) && /manifest/i.test(f)));
 });
 
 test('computeParity flags a flag/arg drift between a bundle and the manifest', () => {
   const bash = parseBashBundle(BASH_FIXTURE);
-  bash.required.find((e) => e.id === 'validate-docs-frontmatter').args = []; // dropped --strict
-  const findings = computeParity({
-    manifest: MANIFEST_FIXTURE,
-    bash,
-    pwsh: parsePwshBundle(PWSH_FIXTURE),
-    ci: parseCiWorkflow(CI_FIXTURE),
-  });
+  bash.required.find((e) => e.id === 'validate-docs-frontmatter').args = []; // dropped --strict locally
+  const findings = computeParity(parityArgs({ bash }));
   assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /arg/i.test(f)));
 });
 
-test('computeParity flags a CI enforcing-level mismatch against the manifest', () => {
+// --- P1 regression: CI per-leg coverage (args + per-OS enforcement) ---
+
+test('computeParity flags CI arg drift when a flag is dropped from one CI leg', () => {
   const ci = parseCiWorkflow(CI_FIXTURE);
-  ci.find((e) => e.id === 'check-context-currency').enforcing = true; // manifest says advisory
-  const findings = computeParity({
-    manifest: MANIFEST_FIXTURE,
-    bash: parseBashBundle(BASH_FIXTURE),
-    pwsh: parsePwshBundle(PWSH_FIXTURE),
-    ci,
-  });
-  assert.ok(findings.some((f) => /check-context-currency/.test(f) && /enforc/i.test(f)));
+  leg(ci, 'validate-docs-frontmatter', 'bash').args = []; // CI silently dropped --strict
+  const findings = computeParity(parityArgs({ ci }));
+  assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /bash/.test(f) && /CI arg drift/.test(f)));
+});
+
+test('computeParity flags per-OS CI enforcement asymmetry (one leg made advisory)', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  leg(ci, 'validate-docs-frontmatter', 'pwsh').enforcing = false; // windows leg -> continue-on-error
+  const findings = computeParity(parityArgs({ ci }));
+  assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /pwsh/.test(f) && /enforc/i.test(f)));
+});
+
+test('computeParity flags a manifest CI validator whose OS leg is missing entirely', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE).filter((l) => !(l.id === 'validate-docs-frontmatter' && l.shell === 'pwsh'));
+  const findings = computeParity(parityArgs({ ci }));
+  assert.ok(findings.some((f) => /validate-docs-frontmatter/.test(f) && /pwsh/.test(f)));
+});
+
+test('computeParity flags a CI leg whose enforcing level disagrees with the manifest', () => {
+  const ci = parseCiWorkflow(CI_FIXTURE);
+  leg(ci, 'check-context-currency', 'bash').enforcing = true; // manifest says advisory
+  const findings = computeParity(parityArgs({ ci }));
+  assert.ok(findings.some((f) => /check-context-currency/.test(f) && /bash/.test(f) && /enforc/i.test(f)));
 });


### PR DESCRIPTION
## What

Resolves all three findings from the Codex adversarial review of `v2.25.1..HEAD`, run via `codex:adversarial-review` before cutting v2.25.2.

## Findings resolved

- **P1 (release-gate integrity)** - `check-validator-parity.mjs` collapsed CI invocations to `{id, enforcing: any-leg}` and ignored CI args, so CI could silently drop `--strict` from one leg, or make the Windows leg `continue-on-error` while Ubuntu still enforced, and the referee would still pass. Now `parseCiWorkflow` returns one record per OS leg (shell + args + enforcing) and `computeParity` checks each leg's args and enforcement against the manifest. +7 tests (15 total). The real tree still PASSES, which confirms the manifest already mirrors every leg.
- **P2 (scar guard false positive)** - `check-emdash-scars.mjs` stripped only single-backtick spans, so a multi-backtick span became `x . x` and was flagged. Now that the guard enforces, that false positive could block CI on legitimate prose. Switched to a balanced N-backtick-run match. +2 tests (10 total).
- **P2 (doc overstatement)** - the v2.25.2 plan G0 ledger claimed the pre-tag bundle is manifest-checked by the referee; it is CI-only. Reworded G0; recorded this review and its resolution in the G1 attestation.

## Verification

25 unit tests pass; both referees green on the real tree; pre-tag bundle `ALL CHECKS PASSED`. CHANGELOG `[Unreleased]` entries refined to describe the per-leg + multi-backtick behavior accurately.
