### PR TITLE
docs(v2.25.2): post-tag hygiene - flip plan to SHIPPED + stage v2.26.0

### DIFF
--- a/docs/internal/release-plans/v2.25.2/plan_v2.25.2.md
+++ b/docs/internal/release-plans/v2.25.2/plan_v2.25.2.md
@@ -1,6 +1,6 @@
 # v2.25.2 Release Plan: Maintenance patch (bank post-v2.25.1 accumulation)
 
-**Status:** RELEASE-PREP IN FLIGHT (cutting 2026-06-10 via the 6-gate runbook; G0 + G1 passed; release-prep PR being cut now). Flips to SHIPPED with the tag SHA at G4.
+**Status:** SHIPPED 2026-06-10 (tag `v2.25.2` at `f7f3622`; GitHub Release Latest; squash-merged PR #184; Validation + Validate Plugin Packaging green on main + tag; the `codex:adversarial-review` findings were resolved in #183; Pages deploy + CodeQL re-run past a transient GitHub API 401 incident that hit both the runner `GITHUB_TOKEN` and the local gh CLI). No new skills (catalog 65/5).
 **Owner:** Maintainers
 **Type:** **PATCH** (maintenance only: no consumable-surface change; catalog stays 30 phase + 9 foundation + 11 utility + 15 tool = 65 skills and 5 sub-agents; the sole version bump banks accumulated maintenance, not a capability delta).
 **Theme:** Bank the maintenance accumulated since v2.25.1 (the final Codex-audit follow-ups) under one versioned GitHub Release. No new skills, no behavior change.
@@ -25,7 +25,9 @@ When cut, G2 (via `pm-changelog-curator`) confirms `[Unreleased]` is complete, t
 | Codex audit P1 follow-ups: `check-root-doc-links` source-surface scan (P1-01), `validate-skill-history` reads `metadata.version` (P1-03), agent + runbook path repoints (P1-02) | `727bbbc` (#178) | `docs/internal/audit/2026-06-06_codex_review.md` (follow-up list) | Yes (Changed + Fixed) |
 | Codex audit now tracked: inline `🔵 CLAUDE` annotations + companion review doc | `20af801` (#177) | the audit + review docs themselves | n/a (internal docs only) |
 | v2.25.1 post-tag hygiene: plan + CONTEXT flips to SHIPPED | `50f564d` (#176) | `docs/internal/release-plans/v2.25.1/plan_v2.25.1.md` | n/a (internal docs only) |
-| Release-gate hygiene: `check-emdash-scars` promoted to enforcing + inline-code-aware; `CLAUDE.md` gitignored-claim correction (audit follow-up #4); `resource-index/` spec archived from `_unreleased/` to `v2.25.1/`; Dependabot triage (#152 closed stale, #179 held for family-version coordination) | (this PR) | the audit review + this plan | Yes (Changed + Fixed) |
+| Release-gate hygiene: `check-emdash-scars` promoted to enforcing + inline-code-aware; `CLAUDE.md` gitignored-claim correction (audit follow-up #4); `resource-index/` spec archived from `_unreleased/` to `v2.25.1/`; Dependabot triage (#152 closed stale, #179 held for family-version coordination) | `8067beb` (#182) | the audit review + this plan | Yes (Changed + Fixed) |
+| Codex adversarial-review fixes: per-leg CI parity in the referee (P1), multi-backtick scar handling (P2), G0 wording correction (P2) | `1078095` (#183) | the `codex:adversarial-review` findings | Yes (refined Added/Changed) |
+| Release-prep: version + CHANGELOG + release notes + CONTEXT markers; a missing-slug fix on `Release_v2.25.2.md` (caught only by the CI rendered-links check) | `f7f3622` (#184) | this plan | n/a (release surfaces) |
 
 ## Release surfaces (G2)
 
@@ -39,14 +41,15 @@ When cut, G2 (via `pm-changelog-curator`) confirms `[Unreleased]` is complete, t
 
 ## Gate ledger (to run at cut time)
 
-- [ ] G0 Pre-tag readiness (the pre-tag bundle runs the enforcing validators; bash/pwsh/CI inventory parity is checked by `check-validator-parity.mjs` in CI, NOT by the local bundle, so confirm it from the validation workflow on the release PR; counters unchanged at 65/5; governance audit 0 P0)
-- [ ] G1 Adversarial review attestation (a Codex adversarial review of the `v2.25.1..HEAD` diff was run 2026-06-10 via `codex:adversarial-review`; it found 1 P1 + 2 P2, all resolved before cut: the parity referee now does per-leg CI checks (args + per-OS enforcement), the scar guard handles multi-backtick spans, and this G0 wording was corrected; the referee + scar guard carry 15 + 10 unit tests)
-- [ ] G2 Version bump + CHANGELOG move (curator; leak check; version-consistency + context-currency PASS)
-- [ ] G2.5 Commit release-prep + PR + CI green both OS legs + CodeQL; squash-merge to main
-- [ ] G3 Annotated tag `v2.25.2` on the post-squash-merge main SHA + push
-- [ ] G4 Post-tag hygiene (GitHub Release Latest; `agent-plugins` registry re-pin; Pages deploy; flip this plan to SHIPPED)
+- [x] G0 Pre-tag readiness (pre-tag bundle ALL CHECKS PASSED; counts re-derived 65/5; cross-cutting audit 0 P0; catalog unchanged since the clean v2.25.1 audit, only 2 agent-doc path repoints)
+- [x] G1 Adversarial review attestation (a Codex adversarial review of `v2.25.1..HEAD` ran 2026-06-10 via `codex:adversarial-review`; 1 P1 + 2 P2, all resolved in #183: per-leg CI parity in the referee, multi-backtick scar handling, and the G0 wording correction; referee + scar guard carry 15 + 10 unit tests)
+- [x] G2 Version bump + CHANGELOG move (2.25.1 -> 2.25.2 across all manifests + README + both CONTEXT markers; CHANGELOG moved to [2.25.2] - 2026-06-10; release notes + site mirror added; version-consistency + context-currency PASS; leak check clean)
+- [x] G2.5 Commit release-prep + PR #184 + CI green both OS legs (CI caught a missing release-notes `slug` the local bundle could not see, since the bundle never builds the site; fixed + re-verified with a local build); squash-merged to main `f7f3622`
+- [x] G3 Annotated tag `v2.25.2` on `f7f3622` (the post-squash-merge SHA, per D22) + pushed; tag CI green (Release + Validate Plugin Packaging)
+- [x] G4 Post-tag hygiene (GitHub Release Latest published; Pages deploy + CodeQL re-run past a transient GitHub API 401 incident; this plan flipped to SHIPPED; `agent-plugins` registry re-pin tracked as a follow-up; v2.26.0 next-cycle plan created)
 
 ## Notes
 
 - The runbook-path drift the v2.25.1 plan flagged for "later" (conductor + auditor + runbook citing the pre-Pattern-S `docs/{contributing,releases}/` paths) is **resolved** in this batch by #178 (P1-02). The release runbook the conductor reads now points at the live `site/src/content/docs/...` paths.
-- This is a pre-stage: do not bump versions or tag until the cut is requested. Keep banking additional maintenance into `[Unreleased]` until then; add rows here as commits land.
+- SHIPPED via the 6-gate runbook embodied inline (auditor at G0 + the CHANGELOG move at G2 done inline, since the plugin sub-agents were not dispatchable in this environment). The one G2.5 CI failure (a missing `slug` on the release-notes page) is the recurring lesson that `validation.yml` is a superset of the local pre-tag bundle: the broken route only existed post-build, which only CI checks.
+- Follow-up: `agent-plugins` registry re-pin to v2.25.2 (the marketplace listing); not blocking, the install path is git-tag-based.

--- a/docs/internal/release-plans/v2.26.0/plan_v2.26.0.md
+++ b/docs/internal/release-plans/v2.26.0/plan_v2.26.0.md
@@ -1,0 +1,46 @@
+# v2.26.0 Release Plan: Authoring + quality layer (workflow builder, ad-hoc chaining, skill-quality convergence)
+
+**Status:** PLANNED (scope staged 2026-06-10; per-item specs + implementation plans NOT yet written). This plan stages the v2.26.0 scope; the next working session creates the spec and implementation plan for each item (see the session-log continuation prompt that accompanies this plan).
+**Owner:** Maintainers
+**Type:** **MINOR** (additive capability: F-14 and F-15 add new authoring tools; F-12 is a quality pass over existing skills. No breaking changes. The catalog grows if F-14/F-15 ship as skills.)
+**Theme:** Close the authoring + quality gap. After v2.25.x hardened the release gate and activation layer, v2.26.0 turns to the contributor/user authoring experience (build workflows, chain skills ad hoc) and a deliberate quality-convergence pass over the existing catalog.
+**Created:** 2026-06-10
+**Companion to:** the effort briefs under `docs/internal/efforts/` and GitHub issues #135 / #133 / #134.
+
+---
+
+## Why this scope, why now
+
+The v2.25.x line (manifest + parity gate, activation hooks, audit closure) finished the release-gate and trust work. The next-largest gaps in the backlog are all authoring/quality, and three have effort briefs already: a workflow builder (#133), ad-hoc skill chaining (#134), and a skill-quality convergence pass (#135). They cohere as one minor: two new authoring tools plus a quality sweep of what already exists. The audit's novel follow-up #5 (a static Skill Finder + optional output schemas) is a candidate to fold in or split out; the next session decides.
+
+## Scope - what v2.26.0 ships (each gets a spec + implementation plan next session)
+
+| Item | Issue | Effort brief | One-line intent |
+|---|---|---|---|
+| **F-14 Workflow Builder** | #133 | `docs/internal/efforts/F-14-workflow-builder.md` | A `utility-workflow-builder` skill: the workflow analogue of `utility-pm-skill-builder`. Guides a user from "I want a workflow for X" to a complete `_workflows/*.md` + `commands/workflow-*.md` + regenerated docs, with a Why-Gate and overlap check. |
+| **F-15 Ad-Hoc Skill Chaining** | #134 | `docs/internal/efforts/F-15-skill-chaining.md` | A lightweight `/chain` capability to sequence skills at runtime WITHOUT authoring a workflow file (the "pipe commands ad hoc" to F-14's "write a shell script"). Passes context between steps; ephemeral, not committed. |
+| **F-12 Skill Quality Convergence** | #135 | `docs/internal/efforts/F-12-skill-quality-convergence.md` | First at-scale use of the `pm-skill-validate` -> `pm-skill-iterate` lifecycle: bring existing domain skills up to the current quality standard, creating the first `HISTORY.md` rows + version bumps for older skills. |
+
+**Candidate (decide next session):** audit follow-up #5 - a static in-site Skill Finder + `skill-manifest.json`, and optional output schemas for a few artifact skills (PRD/hypothesis/results). Novel + worthwhile per the 2026-06-06 audit review; either folds into v2.26.0 or becomes v2.27.0.
+
+## Sequencing + dependencies (for the spec session)
+
+- **F-14 and F-15 are siblings** and should be specced together: F-14 authors a durable workflow file; F-15 runs an ephemeral chain. They share the "select + sequence skills, pass context between steps" core; design the shared engine once. F-15 may be able to reuse the `pm-workflow-orchestrator` (v2.24.0) execution path; F-14 produces a file the orchestrator can later run. Confirm the boundary with the orchestrator so they compose rather than duplicate.
+- **F-12 is independent** but has a prerequisite: **M-13 (Convention Alignment)** should pass first so all skills clear the structural tier before the quality (Tier 2) sweep. F-12 also exercises `pm-skill-validate`/`pm-skill-iterate` at scale - confirm those tools are current.
+- **Brief staleness to fix at spec time:** the F-12 brief predates the current catalog (it references "25 domain skills" and the "v2.8 standard"); re-scope it to the current 65-skill catalog and the current validator tiers when writing its spec.
+
+## How each item becomes shipped (the standard pipeline)
+
+For each of F-12 / F-14 / F-15, the next session produces:
+1. **Spec** at `docs/internal/release-plans/v2.26.0/spec_<slug>.md` (or per-item) - problem, design, interface, acceptance, open questions resolved.
+2. **Implementation plan** at `docs/internal/release-plans/v2.26.0/implementation-plan_<slug>.md` - task-by-task, test-first where the repo convention applies.
+3. **GitHub issue reconciliation** - #133/#134/#135 already exist; set the milestone to v2.26.0 and confirm Type + Agent labels.
+4. Then build -> the standard ship pipeline (per-skill `HISTORY.md`, CHANGELOG, release notes) under the 6-gate runbook.
+
+## Gate ledger (later, at cut time)
+
+- [ ] G0 Pre-tag readiness  - [ ] G1 Adversarial review  - [ ] G2 Version bump + CHANGELOG  - [ ] G2.5 Commit + re-verify  - [ ] G3 Tag + push  - [ ] G4 Post-tag hygiene
+
+## Notes
+
+- This is a scope-staging plan only. Do not bump versions or author skill files from this document; the specs come first. Open the spec work via the continuation prompt in the accompanying session log.


### PR DESCRIPTION
G4 post-tag hygiene for v2.25.2.

- `plan_v2.25.2.md` flipped to SHIPPED (tag `f7f3622`; gate ledger checked; scope table finalized with the #182/#183/#184 SHAs).
- Staged `docs/internal/release-plans/v2.26.0/plan_v2.26.0.md` (MINOR; F-12 / F-14 / F-15 scope; per-item specs + implementation plans pending the next session).

The deep session log + verbose continuation prompt live in `agents/session-log/` (gitignored, local-only by convention). Follow-up: `agent-plugins` registry re-pin to v2.25.2.