### PR TITLE
fix(site): de-rot landing page + enforce per-family card counts (WS-A1)

### DIFF
--- a/scripts/check-landing-page-counts.md
+++ b/scripts/check-landing-page-counts.md
@@ -13,6 +13,19 @@ Stale count claims on user-facing landing pages:
 
 For each page, the validator scans for patterns like `<N> skills`, `<N> AI agent skills`, `<N> production-ready skills` (allowing 0-4 adjective tokens between the number and the resource word), and asserts that every detected count either matches the source-of-truth filesystem count OR appears alongside the source-of-truth count somewhere in the file (in which case stale numbers are treated as historical context).
 
+### Homepage per-family checks (WS-A1, v2.26.0)
+
+<!-- count-exempt:start - illustrative per-family subset numbers, not total-count claims -->
+The homepage CardGrid claims a per-family count in every card title (`Discover (5 skills)`, `Utility (11 skills)`, ...) and the cross-cutting prose list claims three more (`**Foundation (9)**`, `**Utility (11)**`, `**Workshop tools (15)**`). Those lines sit inside or beside a `count-exempt` block because `check-count-consistency` would misread the subset numbers as stale totals; the 2026-06-09 audit found that carve-out had let the cards rot silently (Foundation 8 vs 9, Utility 10 vs 11, cards summing 63 under a 65 headline) - the per-page check above was satisfied because the correct total also appears in the file (the "historical context" escape hatch).
+<!-- count-exempt:end -->
+
+The per-family checks close that class:
+
+- Every parsed card title `Family (N skills)` must match the count of `skills/<family>-*` directories.
+- The card counts must sum to the total catalog count (catches a missing or extra card).
+- The three bold prose family claims must match their family counts (`Workshop tools` maps to the `tool-` prefix).
+- A parse miss is itself a FAIL: zero cards parsed, or a missing prose pattern, fails the check rather than silently skipping it. If you restructure the homepage markup or reword the family prose, update the patterns in both script twins in the same change.
+
 ## What it does NOT catch (by design)
 
 - Counts inside `CHANGELOG.md`, `docs/changelog.md`, `docs/releases/`, or `docs/internal/` (these are historical archives by convention)

--- a/scripts/check-landing-page-counts.ps1
+++ b/scripts/check-landing-page-counts.ps1
@@ -68,11 +68,103 @@ function Test-LandingPage {
   }
 }
 
+# --- Per-family checks on the docs homepage (WS-A1, v2.26.0) ---
+# Parity with check-landing-page-counts.sh: every homepage card title
+# ("Family (N skills)") and the three bold prose family claims must match the
+# skills/<prefix>-* filesystem count; the cards must sum to the catalog total;
+# a parse miss is itself a FAIL so a markup rewrite cannot silently disable
+# the check. See the .sh twin for the full rationale (2026-06-09 audit).
+
+function Get-FamilySkillCount {
+  param([string]$Prefix)
+  return (Get-ChildItem -Path (Join-Path $Root 'skills') -Directory -Filter "$Prefix-*").Count
+}
+
+function Test-HomepageCards {
+  $file = Join-Path $Root 'site/src/content/docs/index.mdx'
+  $label = 'Homepage cards'
+
+  if (-not (Test-Path $file)) {
+    Write-Host "  SKIP: $file (not present)"
+    return
+  }
+
+  $content = Get-Content -Path $file -Raw -Encoding UTF8
+  $cards = [regex]::Matches($content, '<Card title="([A-Za-z]+) \((\d+) skills?\)"')
+
+  if ($cards.Count -eq 0) {
+    Write-Host "  FAIL: $label - no '<Card title=`"Family (N skills)`">' patterns parsed; homepage markup changed?"
+    $failures.Add("$file`: per-card check parsed zero cards; update check-landing-page-counts alongside the markup") | Out-Null
+    return
+  }
+
+  $sum = 0
+  foreach ($m in $cards) {
+    $family = $m.Groups[1].Value
+    $n = [int]$m.Groups[2].Value
+    $prefix = $family.ToLower()
+    $actual = Get-FamilySkillCount $prefix
+    $sum += $n
+    if ($actual -eq 0) {
+      Write-Host "  FAIL: $label - card family '$family' matches no skills/$prefix-* directories"
+      $failures.Add("$file`: card family '$family' has no matching skill directories") | Out-Null
+    } elseif ($n -ne $actual) {
+      Write-Host "  FAIL: $label - '$family ($n skills)' but skills/$prefix-* has $actual"
+      $failures.Add("$file`: card '$family' claims $n; actual $actual") | Out-Null
+    } else {
+      Write-Host "  OK:   $label - $family ($n skills) matches filesystem"
+    }
+  }
+
+  if ($sum -ne $skillCount) {
+    Write-Host "  FAIL: $label - cards sum to $sum but the catalog has $skillCount skills (missing or extra card?)"
+    $failures.Add("$file`: card sum $sum != catalog total $skillCount") | Out-Null
+  } else {
+    Write-Host "  OK:   $label - cards sum to catalog total $skillCount"
+  }
+}
+
+function Test-HomepageProseFamily {
+  param([string]$Display, [string]$Prefix)
+  $file = Join-Path $Root 'site/src/content/docs/index.mdx'
+  $label = 'Homepage family prose'
+
+  if (-not (Test-Path $file)) {
+    Write-Host "  SKIP: $file (not present)"
+    return
+  }
+
+  $content = Get-Content -Path $file -Raw -Encoding UTF8
+  $m = [regex]::Match($content, "\*\*$([regex]::Escape($Display)) \((\d+)\)\*\*")
+
+  if (-not $m.Success) {
+    Write-Host "  FAIL: $label - pattern '**$Display (N)**' not found; homepage prose changed?"
+    $failures.Add("$file`: prose family '$Display' not parsed; update check-landing-page-counts alongside the prose") | Out-Null
+    return
+  }
+
+  $claim = [int]$m.Groups[1].Value
+  $actual = Get-FamilySkillCount $Prefix
+  if ($claim -ne $actual) {
+    Write-Host "  FAIL: $label - '**$Display ($claim)**' but skills/$Prefix-* has $actual"
+    $failures.Add("$file`: prose '$Display' claims $claim; actual $actual") | Out-Null
+  } else {
+    Write-Host "  OK:   $label - $Display ($claim) matches filesystem"
+  }
+}
+
 Write-Host "Checking landing pages:"
 Test-LandingPage (Join-Path $Root 'site/src/content/docs/index.mdx') $skillCount 'skills' 'Docs site homepage'
 Test-LandingPage (Join-Path $Root 'site/src/content/docs/skills/index.md') $skillCount 'skills' 'Skills landing page'
 Test-LandingPage (Join-Path $Root 'site/src/content/docs/workflows/index.md') $workflowCount 'workflows' 'Workflows landing page'
 Test-LandingPage (Join-Path $Root 'library/skill-output-samples/README_SAMPLES.md') $skillCount 'skills' 'Samples library README'
+
+Write-Host ""
+Write-Host "Checking homepage per-family counts:"
+Test-HomepageCards
+Test-HomepageProseFamily 'Foundation' 'foundation'
+Test-HomepageProseFamily 'Utility' 'utility'
+Test-HomepageProseFamily 'Workshop tools' 'tool'
 
 Write-Host ""
 

--- a/scripts/check-landing-page-counts.sh
+++ b/scripts/check-landing-page-counts.sh
@@ -99,11 +99,114 @@ check_landing_page() {
       echo "  FAIL: $label ($file) - claims${stale_counts} but actual is $expected; no $expected anywhere in file"
       FAIL=1
       FAIL_DETAILS+=("$file claims stale count(s)${stale_counts}; expected $expected")
-      return 1
+      # Return 0: the script runs under set -e, so a non-zero return from a
+      # bare top-level call would abort before the remaining checks and the
+      # summary. $FAIL carries the failure to the exit-code decision.
+      return 0
     fi
   else
     echo "  OK:   $label ($file) - all count claims match $expected"
     return 0
+  fi
+}
+
+# --- Per-family checks on the docs homepage (WS-A1, v2.26.0) ---
+#
+# The homepage CardGrid claims a per-family count in every card title
+# ("Discover (5 skills)", "Utility (11 skills)", ...) and the cross-cutting
+# prose list claims three more ("**Foundation (9)**", "**Utility (11)**",
+# "**Workshop tools (15)**"). Those lines live inside or beside a count-exempt
+# block because check-count-consistency would misread the subset numbers as
+# stale totals. The 2026-06-09 audit found that carve-out had let the cards rot
+# (Foundation 8 vs 9, Utility 10 vs 11, cards summing 63 under a 65 headline).
+# These checks make the per-family numbers enforced: every parsed claim must
+# match the filesystem, the card counts must sum to the catalog total, and a
+# parse miss (zero cards, missing prose pattern) is itself a FAIL so a markup
+# rewrite cannot silently disable the check. If you restructure the homepage,
+# update these patterns in the same change.
+
+family_skill_count() {
+  find "$ROOT/skills" -mindepth 1 -maxdepth 1 -type d -name "$1-*" | wc -l | tr -d ' '
+}
+
+check_homepage_cards() {
+  local file="$ROOT/site/src/content/docs/index.mdx"
+  local label="Homepage cards"
+
+  if [ ! -f "$file" ]; then
+    echo "  SKIP: $file (not present)"
+    return 0
+  fi
+
+  local card_lines
+  card_lines=$(grep -oE '<Card title="[A-Za-z]+ \([0-9]+ skills?\)"' "$file" || true)
+
+  if [ -z "$card_lines" ]; then
+    echo "  FAIL: $label - no '<Card title=\"Family (N skills)\">' patterns parsed; homepage markup changed?"
+    FAIL=1
+    FAIL_DETAILS+=("$file: per-card check parsed zero cards; update check-landing-page-counts alongside the markup")
+    return 0
+  fi
+
+  local sum=0
+  local family n prefix actual
+  while IFS= read -r card; do
+    family=$(printf '%s' "$card" | sed -E 's/<Card title="([A-Za-z]+) \([0-9]+ skills?\)"/\1/')
+    n=$(printf '%s' "$card" | grep -oE '\([0-9]+' | tr -d '(')
+    prefix=$(printf '%s' "$family" | tr '[:upper:]' '[:lower:]')
+    actual=$(family_skill_count "$prefix")
+    sum=$((sum + n))
+    if [ "$actual" -eq 0 ]; then
+      echo "  FAIL: $label - card family '$family' matches no skills/${prefix}-* directories"
+      FAIL=1
+      FAIL_DETAILS+=("$file: card family '$family' has no matching skill directories")
+    elif [ "$n" -ne "$actual" ]; then
+      echo "  FAIL: $label - '$family ($n skills)' but skills/${prefix}-* has $actual"
+      FAIL=1
+      FAIL_DETAILS+=("$file: card '$family' claims $n; actual $actual")
+    else
+      echo "  OK:   $label - $family ($n skills) matches filesystem"
+    fi
+  done <<< "$card_lines"
+
+  if [ "$sum" -ne "$SKILL_COUNT" ]; then
+    echo "  FAIL: $label - cards sum to $sum but the catalog has $SKILL_COUNT skills (missing or extra card?)"
+    FAIL=1
+    FAIL_DETAILS+=("$file: card sum $sum != catalog total $SKILL_COUNT")
+  else
+    echo "  OK:   $label - cards sum to catalog total $SKILL_COUNT"
+  fi
+}
+
+check_homepage_prose_family() {
+  local display="$1"   # bold prose label, e.g. "Workshop tools"
+  local prefix="$2"    # skills/ directory prefix, e.g. "tool"
+  local file="$ROOT/site/src/content/docs/index.mdx"
+  local label="Homepage family prose"
+
+  if [ ! -f "$file" ]; then
+    echo "  SKIP: $file (not present)"
+    return 0
+  fi
+
+  local claim
+  claim=$(grep -oE "\*\*${display} \([0-9]+\)\*\*" "$file" | grep -oE '[0-9]+' | head -1 || true)
+
+  if [ -z "$claim" ]; then
+    echo "  FAIL: $label - pattern '**${display} (N)**' not found; homepage prose changed?"
+    FAIL=1
+    FAIL_DETAILS+=("$file: prose family '$display' not parsed; update check-landing-page-counts alongside the prose")
+    return 0
+  fi
+
+  local actual
+  actual=$(family_skill_count "$prefix")
+  if [ "$claim" -ne "$actual" ]; then
+    echo "  FAIL: $label - '**${display} ($claim)**' but skills/${prefix}-* has $actual"
+    FAIL=1
+    FAIL_DETAILS+=("$file: prose '$display' claims $claim; actual $actual")
+  else
+    echo "  OK:   $label - $display ($claim) matches filesystem"
   fi
 }
 
@@ -112,6 +215,13 @@ check_landing_page "$ROOT/site/src/content/docs/index.mdx" "$SKILL_COUNT" "skill
 check_landing_page "$ROOT/site/src/content/docs/skills/index.md" "$SKILL_COUNT" "skills" "Skills landing page"
 check_landing_page "$ROOT/site/src/content/docs/workflows/index.md" "$WORKFLOW_COUNT" "workflows" "Workflows landing page"
 check_landing_page "$ROOT/library/skill-output-samples/README_SAMPLES.md" "$SKILL_COUNT" "skills" "Samples library README"
+
+echo ""
+echo "Checking homepage per-family counts:"
+check_homepage_cards
+check_homepage_prose_family "Foundation" "foundation"
+check_homepage_prose_family "Utility" "utility"
+check_homepage_prose_family "Workshop tools" "tool"
 
 echo ""
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -49,7 +49,7 @@ graph LR
 
 ## The Skills
 
-{/* count-exempt:start */}
+{/* count-exempt:start - per-family subset counts; the total-count scan would misread them as stale totals. Each card's number IS enforced: check-landing-page-counts verifies every card against skills/<family>-* and requires the cards to sum to the catalog total. */}
 <CardGrid>
   <Card title="Discover (5 skills)" icon="magnifier">
     Research, competitive analysis, stakeholder mapping.
@@ -87,14 +87,14 @@ graph LR
     [Browse Iterate](skills/iterate/)
   </Card>
 
-  <Card title="Foundation (8 skills)" icon="open-book">
-    Cross-cutting skills: persona, OKR writer, lean canvas, meeting lifecycle, stakeholder update.
+  <Card title="Foundation (9 skills)" icon="open-book">
+    Cross-cutting skills: persona, OKR writer, lean canvas, meeting lifecycle, stakeholder update, prioritized action plan.
 
     [Browse Foundation](skills/foundation/)
   </Card>
 
-  <Card title="Utility (10 skills)" icon="pencil">
-    Create, validate, iterate skills, generate diagrams and presentations, and update the library.
+  <Card title="Utility (11 skills)" icon="pencil">
+    Create, validate, iterate skills, run governed multi-skill workflows, generate diagrams and presentations, and update the library.
 
     [Browse Utility](skills/utility/)
   </Card>
@@ -175,9 +175,9 @@ block-beta
 
 **Beyond the six phases**, three cross-cutting families support the work at every stage:
 
-- **Foundation (8)** - reusable building blocks for any initiative: `foundation-persona`, `foundation-lean-canvas`, `foundation-okr-writer`, `foundation-stakeholder-update`, and the four meeting skills (agenda, brief, recap, and cross-meeting synthesis).
+- **Foundation (9)** - reusable building blocks for any initiative: `foundation-persona`, `foundation-lean-canvas`, `foundation-okr-writer`, `foundation-stakeholder-update`, `foundation-prioritized-action-plan`, and the four meeting skills (agenda, brief, recap, and cross-meeting synthesis).
 - **Workshop tools (15)** - run a facilitated session with your agent: the 7-skill **Foundation Sprint** family for 2-day strategic alignment, the 7-skill **Design Sprint** family for a 5-day prototype-and-test cycle, and the standalone `tool-note-and-vote` decision mechanic.
-- **Utility (10)** - meta-tooling that builds, validates, and maintains the library itself, plus the sub-agents that run adversarial review, catalog auditing, changelog curation, and release orchestration.
+- **Utility (11)** - meta-tooling that builds, validates, and maintains the library itself, plus `utility-pm-workflow-orchestrator` for governed multi-skill runs and the sub-agents that handle adversarial review, catalog auditing, changelog curation, and release orchestration.
 
 ## The Skill Lifecycle
 
@@ -284,16 +284,16 @@ Follow three fictional companies through the complete product lifecycle - from d
 {/* count-exempt:start */}
 | Version | Date | Highlights |
 |---------|------|-----------|
+| **[v2.25.2](releases/Release_v2.25.2.md)** | 2026-06-10 | Maintenance patch: a single manifest now declares every release-gate validator, with an enforcing CI parity referee so the bash, PowerShell, and CI inventories cannot drift. Closes the 2026-06-06 audit. |
+| **[v2.25.1](releases/Release_v2.25.1.md)** | 2026-06-06 | Maintenance patch: docs site moves to the family `site/` layout (Pattern S), a generated CI-gated resource index, root-link repair with an enforcing guard, and an em-dash-scar cleanup. |
+| **[v2.25.0](releases/Release_v2.25.0.md)** | 2026-06-03 | The plugin's first hooks: opt-in house-rule guardrails and a confident-only phase router, plus an advisory output-quality CI tier. No new skills. |
+| **[v2.24.0](releases/Release_v2.24.0.md)** | 2026-06-01 | `utility-pm-workflow-orchestrator` runs a prioritized action plan through its recommended pm-skills with go/no-go checkpoints. Ships EXPERIMENTAL. Catalog grows 64 to 65. |
+| **[v2.23.0](releases/Release_v2.23.0.md)** | 2026-05-31 | `foundation-prioritized-action-plan` turns rough notes, transcripts, or a vague ask into one prioritized action plan with honest confidence levels. Catalog grows 63 to 64. |
 | **[v2.22.0](releases/Release_v2.22.0.md)** | 2026-05-30 | One menu entry per skill: the 63 duplicate command wrappers are gone, so each capability shows once. Native Codex support added via a `.codex-plugin` manifest. All 65 skills unchanged. |
 | **[v2.21.0](releases/Release_v2.21.0.md)** | 2026-05-26 | Marketplace launch: pm-skills now installs from the `product-on-purpose` plugin marketplace. The previous install path keeps working, so existing setups need no change. |
 | **[v2.20.0](releases/Release_v2.20.0.md)** | 2026-05-25 | Each workshop methodology is now a single command: `/workflow-foundation-sprint`, `/workflow-design-sprint`, and `/workflow-foundation-to-design` chain their per-day skills end to end. |
 | **[v2.19.0](releases/Release_v2.19.0.md)** | 2026-05-23 | Pre-promotion hardening: new validators catch stale counts, dead links, and references to skills that do not exist before they can ship. Nothing you use behaves differently. |
 | **[v2.18.0](releases/Release_v2.18.0.md)** | 2026-05-21 | Four new phase skills close the highest-consensus PM gaps: market-sizing, prioritization-framework, journey-map, and survey-analysis. Catalog grows 59 to 63. |
-| **[v2.17.0](releases/Release_v2.17.0.md)** | 2026-05-20 | Native Claude Code sub-agent registration: `@pm-critic` and the other three auto-discover and dispatch by @-mention. |
-| **[v2.16.0](releases/Release_v2.16.0.md)** | 2026-05-17 | Active Orchestration: 4 sub-agents (pm-critic, pm-skill-auditor, pm-changelog-curator, pm-release-conductor) plus the modernized Astro Starlight docs stack with full-text search. |
-| **[v2.15.0](releases/Release_v2.15.0.md)** | 2026-05-16 | Sprint Skills launch: 15 workshop-methodology skills (Foundation Sprint + Design Sprint families + note-and-vote). Catalog grows 40 to 55. |
-| [v2.14.0](releases/Release_v2.14.0.md) | 2026-05-10 | Docs stack migration from MkDocs Material to Astro Starlight: full-text search and native dark mode. |
-| **[v2.12.0](releases/Release_v2.12.0.md)** | 2026-05-03 | OKR skills: `foundation-okr-writer` and `measure-okr-grader` for the full quarterly write-and-score cycle. |
 
 [All releases](releases/) · [Full changelog](changelog.md)
 {/* count-exempt:end */}


### PR DESCRIPTION
## What

STEP 1 of the v2.26.0 build (WS-A1 in [plan_v2.26.0.md](https://github.com/product-on-purpose/pm-skills/blob/main/docs/internal/release-plans/v2.26.0/plan_v2.26.0.md)): closes the 2026-06-09 audit's landing-page finding.

### Landing page (`site/src/content/docs/index.mdx`)
- Foundation card 8 -> 9, Utility card 10 -> 11; the nine cards now sum to the 65-skill catalog
- `foundation-prioritized-action-plan` and `utility-pm-workflow-orchestrator` added to the cross-cutting family prose lists
- Recent Releases table refreshed through v2.25.2 (adds v2.23.0 .. v2.25.2; drops the five oldest rows)
- The card-grid `count-exempt` span is annotated with why it exists and what enforces the cards now

### Validator (`check-landing-page-counts` .sh / .ps1 / .md)
The audit showed the cards rotted inside the `count-exempt` carve-out while the per-page total check was satisfied by the correct headline ('historical context' escape hatch). New enforcement:
- **Per-card check**: every `Family (N skills)` card title must match the `skills/<family>-*` filesystem count, and the cards must sum to the catalog total
- **Prose-family check**: the three bold family claims (`**Foundation (N)**`, `**Utility (N)**`, `**Workshop tools (N)**`) are verified against the filesystem
- A parse miss (zero cards parsed / missing prose pattern) is itself a FAIL, so a homepage rewrite cannot silently disable the check
- Latent bug fixed: FAIL paths returned 1 from bare top-level function calls under `set -e`, aborting before the summary and breaking the documented non-strict exit-0 contract

## Verification
- `bash scripts/check-landing-page-counts.sh --strict` and `pwsh ... -Strict`: PASS
- Failure path probed in BOTH shells: Foundation 8 reintroduced -> FAIL (per-card + sum), reverted -> PASS
- Full pre-tag bundle: `pre-tag-validate.sh` and `pre-tag-validate.ps1` both ALL CHECKS PASSED
- No validation-manifest change needed (same script names + args, parity gate unaffected)