### PR TITLE
docs(entry): repair stale AGENTS.md references + marketplace-first QUICKSTART (WS-A2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Cross-meeting archaeology skill. Consumes multiple meeting recaps over a period 
 
 Produces async communication to stakeholders from a meeting recap. Supports five channel variants (slack, teams, email, notion, exec-memo) and five audience variants (engineering, design, leadership, customer-facing, mixed). Surfaces primary CTA up front, logs technical-to-business translations, detects thread continuation. Member of the Meeting Skills Family.
 
-> Meeting skills share a contract at `docs/reference/skill-families/meeting-skills-contract.md` governing frontmatter, file naming, go-mode behavior, and universal output requirements. Enforced by `scripts/validate-meeting-skills-family.sh`.
+> Meeting skills share a contract at [meeting-skills-contract](https://product-on-purpose.github.io/pm-skills/reference/skill-families/meeting-skills-contract/) governing frontmatter, file naming, go-mode behavior, and universal output requirements. Enforced by `scripts/validate-meeting-skills-family.sh`.
 
 ---
 
@@ -323,7 +323,7 @@ Structured group-decision mechanic that captures silent ideation, voting summari
 
 #### Foundation Sprint Family
 
-The 7 `tool-foundation-sprint-*` skills implement Knapp and Zeratsky's two-day Foundation Sprint workshop. Family contract: `docs/reference/skill-families/foundation-sprint-skills-contract.md`. Workflow: `_workflows/foundation-sprint.md`.
+The 7 `tool-foundation-sprint-*` skills implement Knapp and Zeratsky's two-day Foundation Sprint workshop. Family contract: [foundation-sprint-skills-contract](https://product-on-purpose.github.io/pm-skills/reference/skill-families/foundation-sprint-skills-contract/). Workflow: `_workflows/foundation-sprint.md`.
 
 ##### tool-foundation-sprint-readiness
 **Path:** `skills/tool-foundation-sprint-readiness/SKILL.md`
@@ -374,7 +374,7 @@ Day 2 end capstone move of a Foundation Sprint. Compresses the sprint's full str
 
 #### Design Sprint Family
 
-The 7 `tool-design-sprint-*` skills implement Knapp, Zeratsky, and Kowitz's five-day Design Sprint workshop. Family contract: `docs/reference/skill-families/design-sprint-skills-contract.md`. Workflow: `_workflows/design-sprint.md`. End-to-end FS-to-DS workflow: `_workflows/foundation-to-design.md`. User guide: `docs/guides/using-design-sprint.md`. Concept doc: `docs/concepts/design-sprint.md`.
+The 7 `tool-design-sprint-*` skills implement Knapp, Zeratsky, and Kowitz's five-day Design Sprint workshop. Family contract: [design-sprint-skills-contract](https://product-on-purpose.github.io/pm-skills/reference/skill-families/design-sprint-skills-contract/). Workflow: `_workflows/design-sprint.md`. End-to-end FS-to-DS workflow: `_workflows/foundation-to-design.md`. User guide: [using-design-sprint](https://product-on-purpose.github.io/pm-skills/guides/using-design-sprint/). Concept doc: [design-sprint](https://product-on-purpose.github.io/pm-skills/concepts/design-sprint/).
 
 ##### tool-design-sprint-readiness
 **Path:** `skills/tool-design-sprint-readiness/SKILL.md`
@@ -465,13 +465,13 @@ v2.24.0 adds a fifth sub-agent:
 
 - `pm-workflow-orchestrator` - governed multi-skill runner that walks an ordered step list (a saved `foundation-prioritized-action-plan` or a user-named chain), pausing for human go/no-go by default and refusing to advance past a failed or empty step. The first repo agent to declare the `Skill` tool to delegate downstream skills (it adds no chain-permission entry and spawns no sub-agents). Ships EXPERIMENTAL on all clients.
 
-The canonical sub-agents catalog with full audience, trigger, lifetime, tool surface, and composition data lives at [`docs/reference/runtime-components.md`](https://github.com/product-on-purpose/pm-skills/blob/main/docs/reference/runtime-components.md). Sub-agent definition files live at `agents/{name}.md`, the fixed path Claude Code's plugin runtime auto-discovers (renamed from `subagents/` in v2.17.0 W2).
+The canonical sub-agents catalog with full audience, trigger, lifetime, tool surface, and composition data lives at the [runtime components reference](https://product-on-purpose.github.io/pm-skills/reference/runtime-components/). Sub-agent definition files live at `agents/{name}.md`, the fixed path Claude Code's plugin runtime auto-discovers (renamed from `subagents/` in v2.17.0 W2).
 
 ### Cross-client compatibility
 
 Sub-agents are a Claude Code plugin feature. Non-Claude clients (Codex CLI, Cursor, Windsurf, Copilot, Gemini CLI) access sub-agent intent via dispatch skills at `skills/utility-pm-{role}/`. Dispatch skills detect runtime and dispatch appropriately: native sub-agent on Claude Code, or "read agent definition and execute inline" on other clients. codex-rescue is an optional shortcut for users with both Claude Code and Codex CLI; it is NOT a baseline requirement.
 
-All 4 dispatch skills shipped in v2.16.0 with Codex CLI VALIDATED 2026-05-17 (GATE B + C PASS). Cursor / Windsurf / Copilot CLI / Gemini CLI status is EXPERIMENTAL pending v2.17 cross-client expansion. See the canonical [Sub-Agent Compatibility Matrix](https://github.com/product-on-purpose/pm-skills/blob/main/docs/reference/sub-agent-compatibility.md) for per-sub-agent + per-client status, safe-usage guidance, and how-to-validate-a-new-client maintainer guide. Mechanism details at [`docs/reference/runtime-components.md#cross-client-compatibility`](https://github.com/product-on-purpose/pm-skills/blob/main/docs/reference/runtime-components.md#cross-client-compatibility).
+All 4 dispatch skills shipped in v2.16.0 with Codex CLI VALIDATED 2026-05-17 (GATE B + C PASS). Cursor / Windsurf / Copilot CLI / Gemini CLI status is EXPERIMENTAL pending v2.17 cross-client expansion. See the canonical [Sub-Agent Compatibility Matrix](https://product-on-purpose.github.io/pm-skills/reference/sub-agent-compatibility/) for per-sub-agent + per-client status, safe-usage guidance, and how-to-validate-a-new-client maintainer guide. Mechanism details at [runtime components: cross-client compatibility](https://product-on-purpose.github.io/pm-skills/reference/runtime-components/#cross-client-compatibility).
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,15 +8,14 @@
 
 ## Installation
 
-### Claude.ai / Claude Desktop
+### Claude Code (recommended: plugin marketplace)
 
-1. Go to **Settings > Capabilities** (Desktop) or **Project Settings > Add Files** (Claude.ai)
-2. Upload the latest release ZIP (`pm-skills-vX.X.X.zip`) from [Releases](https://github.com/product-on-purpose/pm-skills/releases)
-3. Skills are now available in your conversations
+```
+/plugin marketplace add product-on-purpose/agent-plugins
+/plugin install pm-skills@product-on-purpose
+```
 
-### Claude Code
-
-Clone or copy to your project:
+Prefer a file-based install? Clone or copy to your project:
 
 ```bash
 git clone https://github.com/product-on-purpose/pm-skills.git
@@ -24,11 +23,23 @@ git clone https://github.com/product-on-purpose/pm-skills.git
 
 Or download and extract the latest ZIP from [Releases](https://github.com/product-on-purpose/pm-skills/releases) to your project root.
 
+### Claude.ai / Claude Desktop
+
+1. Go to **Settings > Capabilities** (Desktop) or **Project Settings > Add Files** (Claude.ai)
+2. Upload the latest release ZIP (`pm-skills-vX.X.X.zip`) from [Releases](https://github.com/product-on-purpose/pm-skills/releases)
+3. Skills are now available in your conversations
+
 ### Other AI Agents
 
-Point your agent to `AGENTS.md` for skill discovery. Each skill is self-contained in `skills/{skill-name}/SKILL.md` (e.g., `skills/deliver-prd/SKILL.md`).
+Add via the open skills CLI:
 
-More detail: see `docs/getting-started/index.md` for the long-form guide.
+```bash
+npx skills add product-on-purpose/pm-skills
+```
+
+Or point your agent to `AGENTS.md` for skill discovery. Each skill is self-contained in `skills/{skill-name}/SKILL.md` (e.g., `skills/deliver-prd/SKILL.md`).
+
+More detail: see the [Getting Started guide](https://product-on-purpose.github.io/pm-skills/getting-started/) for the long-form walkthrough.
 
 ## Usage
 
@@ -66,7 +77,7 @@ flowchart LR
     Iterate --> Validate
 ```
 
-See `docs/guides/pm-skill-lifecycle.md` for detailed workflow patterns.
+See the [PM Skill Lifecycle guide](https://product-on-purpose.github.io/pm-skills/guides/pm-skill-lifecycle/) for detailed workflow patterns.
 
 ## File Structure
 
@@ -83,7 +94,8 @@ For Claude Code discovery, run `./scripts/sync-claude.sh` (or `.ps1`) to populat
 
 ## Learn More
 
-- Full documentation: https://github.com/product-on-purpose/pm-skills
+- Full documentation: https://product-on-purpose.github.io/pm-skills/
+- GitHub repository: https://github.com/product-on-purpose/pm-skills
 - Skill specification: https://agentskills.io/specification
 
 ---


### PR DESCRIPTION
## What

WS-A2 from the v2.26.0 plan ([plan_v2.26.0.md](https://github.com/product-on-purpose/pm-skills/blob/main/docs/internal/release-plans/v2.26.0/plan_v2.26.0.md)): entry-docs refresh from the 2026-06-09 audit.

### AGENTS.md (8 stale references across 5 lines)
- 5 code-span paths into the retired `docs/(reference|guides|concepts)/` tree converted to deployed-site links: the three family contracts (meeting, foundation-sprint, design-sprint), the using-design-sprint guide, and the design-sprint concept doc
- 3 dead `blob/main/docs/reference/...` GitHub URLs repointed to the deployed site (runtime-components twice, incl. the #cross-client-compatibility anchor, and sub-agent-compatibility)

(The audit counted 7; the third absolute URL on line 474 was the same dead class, so all 8 are fixed.)

### QUICKSTART.md
- Claude Code install is now **marketplace-first** (`/plugin marketplace add` + `/plugin install`), with clone/ZIP as the file-based alternative
- Other AI Agents section adds the open skills CLI (`npx skills add product-on-purpose/pm-skills`)
- `docs/getting-started/index.md` and `docs/guides/pm-skill-lifecycle.md` code spans converted to deployed-site links
- Learn More leads with the docs site

### Noted deviation from the plan row's parenthetical
The row suggested alias-form `docs/<tail>` relative links (gate-visible via the Pattern S alias). Those pass CI but 404 for GitHub readers, so this PR uses the deployed-site URL convention instead (README house style; validated against `route-manifest.txt` by the same enforcing `check-root-doc-links` gate). Same enforcement, and the links are live for humans too.

## Verification
- `node scripts/check-root-doc-links.mjs`: PASS (247 files scanned)
- Full bash pre-tag bundle: ALL CHECKS PASSED
- All 7 deployed routes confirmed present in `scripts/route-manifest.txt` before conversion