### PR TITLE
docs(scripts): retire stale Python-generator references in check-workflow-generator-coverage (WS-A3)

### DIFF
--- a/scripts/check-workflow-generator-coverage.md
+++ b/scripts/check-workflow-generator-coverage.md
@@ -1,20 +1,22 @@
 # check-workflow-generator-coverage
 
-Asserts that the workflow generator emits a row in `docs/workflows/index.md` for every source file in `_workflows/*.md`.
+Asserts that the site generator (`scripts/gen-site.mjs`) emits a row in the generated `site/src/content/docs/workflows/index.md` for every source file in `_workflows/*.md`, plus a generated page per workflow. The generated tree is gitignored and rebuilt per build.
 
 ## What it catches
 
-Silent drops where:
+Coverage gaps where:
 
-- A workflow source file in `_workflows/` exists but does not appear as a `| [Display Name](stem.md) |` row in the generated `docs/workflows/index.md`
-- A workflow source file exists but its individual `docs/workflows/<stem>.md` page is missing
+- A workflow source file in `_workflows/` exists but does not appear as a `| [Display Name](stem.md) |` row in the generated `site/src/content/docs/workflows/index.md`
+- A workflow source file exists but its individual `site/src/content/docs/workflows/<stem>.md` page is missing
 - The three counts (source workflows, generated pages, index rows) do not match
+
+The realistic failure modes today are a stale generated tree (the generator was not re-run after a workflow was added) or a generator regression that drops output.
 
 ## Why this validator exists
 
-v2.15.0 shipped 3 new workflows (`foundation-sprint.md`, `design-sprint.md`, `foundation-to-design.md`). The generator script `scripts/generate-workflow-pages.py` correctly wrote the 3 individual page outputs but silently skipped them from the index table because its hardcoded `workflow_info` dict had no entries for them. The `check-generated-content-untouched` validator missed this because it compares generator output to file content (consistency), not generator output to source-of-truth (correctness).
+v2.15.0 shipped 3 new workflows (`foundation-sprint.md`, `design-sprint.md`, `foundation-to-design.md`). The then-current Python generator (`generate-workflow-pages.py`, retired in the v2.25.1 Pattern S reorg) correctly wrote the 3 individual page outputs but silently skipped them from the index table because its hardcoded `workflow_info` dict had no entries for them. The `check-generated-content-untouched` validator missed this because it compares generator output to file content (consistency), not generator output to source-of-truth (correctness).
 
-The v2.15.1 generator hardening raises `SystemExit` when a source file lacks a `workflow_info` entry, providing an author-side fence. This validator is the CI-side fence; both run, defense in depth.
+`scripts/gen-site.mjs` now derives both the pages and the index dynamically from `_workflows/*.md`, so the original hardcoded-dict silent-drop mechanism is structurally gone; this validator remains as the CI-side fence for the surviving failure modes above.
 
 ## What it does NOT catch (by design)
 
@@ -39,4 +41,4 @@ Wired into `.github/workflows/validation.yml` (both Ubuntu + Windows matrix entr
 ## Cross-references
 
 - Audit: `docs/internal/release-plans/v2.15.x/audit_v2.15.x_post-tag-self-review.md` (finding A03)
-- Generator: `scripts/generate-workflow-pages.py` (now hardened to raise SystemExit on missing workflow_info entries)
+- Generator: `scripts/gen-site.mjs` (replaced the retired `generate-workflow-pages.py` in the v2.25.1 Pattern S reorg)

--- a/scripts/check-workflow-generator-coverage.ps1
+++ b/scripts/check-workflow-generator-coverage.ps1
@@ -41,9 +41,9 @@ Write-Host "Checking individual generated pages:"
 foreach ($stem in $sourceStems) {
   $pagePath = Join-Path $WorkflowsOut "$stem.md"
   if (Test-Path $pagePath) {
-    Write-Host "  OK:   $stem.md present in docs/workflows/"
+    Write-Host "  OK:   $stem.md present in site/src/content/docs/workflows/"
   } else {
-    Write-Host "  FAIL: $stem.md missing from docs/workflows/ (source exists but no generated page)"
+    Write-Host "  FAIL: $stem.md missing from site/src/content/docs/workflows/ (source exists but no generated page)"
     $fail = $true
   }
 }
@@ -55,7 +55,7 @@ foreach ($stem in $sourceStems) {
   if ($indexContent -match $linkPattern) {
     Write-Host "  OK:   $stem.md linked from index"
   } else {
-    Write-Host "  FAIL: $stem.md NOT linked from $WorkflowsIndex (silent drop; run generator + add to workflow_info dict)"
+    Write-Host "  FAIL: $stem.md NOT linked from $WorkflowsIndex (stale or incomplete generated index; re-run the generator)"
     $fail = $true
   }
 }
@@ -85,7 +85,6 @@ if (-not $fail) {
   exit 0
 } else {
   Write-Host "FAIL: workflow generator coverage gap detected."
-  Write-Host "Fix: run 'python scripts/generate-workflow-pages.py' AND add any missing"
-  Write-Host "workflow_info entries (plus matching order list entries) in the generator."
+  Write-Host "Fix: re-run 'node scripts/gen-site.mjs' to rebuild the generated site content."
   exit 1
 }

--- a/scripts/check-workflow-generator-coverage.sh
+++ b/scripts/check-workflow-generator-coverage.sh
@@ -11,13 +11,17 @@
 # source-of-truth (correctness).
 #
 # This validator asserts a stronger contract: every workflow source file in
-# _workflows/*.md must appear as a row in docs/workflows/index.md AND have
-# a corresponding individual page in docs/workflows/.
+# _workflows/*.md must appear as a row in the generated
+# site/src/content/docs/workflows/index.md AND have a corresponding generated
+# page in site/src/content/docs/workflows/ (output of scripts/gen-site.mjs,
+# gitignored, rebuilt per build).
 #
-# Note: the generator script itself was also hardened in v2.15.1 to raise
-# SystemExit when a workflow source exists without a workflow_info entry.
-# This validator is the CI-side fence; the generator hardening is the
-# author-side fence. Defense in depth.
+# Note: the Python generator with the hardcoded dict was retired in the
+# Pattern S reorg (v2.25.1); scripts/gen-site.mjs now derives both the pages
+# and the index dynamically from _workflows/*.md, so the original silent-drop
+# mechanism is structurally gone. This validator remains the CI-side fence
+# against the surviving failure modes: a stale generated tree (generator not
+# re-run) or a generator regression that drops output.
 #
 # Exit codes:
 #   0 - All source workflows are covered by the index and have individual pages
@@ -57,9 +61,9 @@ SOURCE_WORKFLOWS=$(find "$WORKFLOWS_SRC" -maxdepth 1 -name '*.md' -type f ! -nam
 echo "Checking individual generated pages:"
 for stem in $SOURCE_WORKFLOWS; do
   if [ -f "$WORKFLOWS_OUT/$stem.md" ]; then
-    echo "  OK:   $stem.md present in docs/workflows/"
+    echo "  OK:   $stem.md present in site/src/content/docs/workflows/"
   else
-    echo "  FAIL: $stem.md missing from docs/workflows/ (source exists but no generated page)"
+    echo "  FAIL: $stem.md missing from site/src/content/docs/workflows/ (source exists but no generated page)"
     FAIL=1
   fi
 done
@@ -73,7 +77,7 @@ for stem in $SOURCE_WORKFLOWS; do
   if grep -qE "\]\(${stem}\.md\)" "$WORKFLOWS_INDEX"; then
     echo "  OK:   $stem.md linked from index"
   else
-    echo "  FAIL: $stem.md NOT linked from $WORKFLOWS_INDEX (silent drop; run generator + add to workflow_info dict)"
+    echo "  FAIL: $stem.md NOT linked from $WORKFLOWS_INDEX (stale or incomplete generated index; re-run the generator)"
     FAIL=1
   fi
 done
@@ -103,7 +107,6 @@ if [ "$FAIL" -eq 0 ]; then
   exit 0
 else
   echo "FAIL: workflow generator coverage gap detected."
-  echo "Fix: run 'python scripts/generate-workflow-pages.py' AND add any missing"
-  echo "workflow_info entries (plus matching order list entries) in the generator."
+  echo "Fix: re-run 'node scripts/gen-site.mjs' to rebuild the generated site content."
   exit 1
 fi


### PR DESCRIPTION
## What

WS-A3 from the v2.26.0 plan ([plan_v2.26.0.md](https://github.com/product-on-purpose/pm-skills/blob/main/docs/internal/release-plans/v2.26.0/plan_v2.26.0.md)).

### Stale doc header fix (`check-workflow-generator-coverage` .sh / .ps1 / .md)
The validator's logic was repointed to `site/src/content/docs/workflows/` during Pattern S, but its doc header, comments, and operator-facing FAIL/fix messages still cited the retired `generate-workflow-pages.py`, its `workflow_info` dict, and the old `docs/workflows/` path. All three files now describe reality: `scripts/gen-site.mjs` derives the pages and the index dynamically from `_workflows/*.md`, so the historic hardcoded-dict silent-drop mechanism is structurally gone; the validator remains the CI-side fence against a stale generated tree or a generator regression. Text-only; no logic touched.

### Code-span sweep result
The other WS-A3 half (sweep remaining backtick `docs/...` code spans in root docs into real links) came back **empty** after WS-A2 (#188) landed its conversions: zero stale `docs/` code spans remain in README / CONTRIBUTING / AGENTS.md / QUICKSTART. CHANGELOG mentions are historical by its documented convention. No conversions needed.

### Note on agent label
The plan row labels WS-A3 `agent:codex`; it was executed inline in the build session per the continuation prompt's bundling authorization (native Codex review/exec remains unavailable here, see `reference_codex-native-review-stalls`).

## Verification
- `check-workflow-generator-coverage` PASS in both shells (12 source / 12 generated / 12 index rows)
- Full bash pre-tag bundle: ALL CHECKS PASSED (includes `validate-script-docs`)