### PR TITLE
feat: F-12 Batch 1 - Deliver cohort quality convergence (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `utility-pm-workflow-orchestrator` 1.1.0: the user-declared dependency flag is now named `--thread`, the completion output suggests promoting a reusable 2+ step chain to the builder, and the always-loaded description is rewritten to lead with triggers and boundaries (client-routing mechanics stay in the body). First `HISTORY.md` added.
+- Deliver-cohort quality convergence (F-12 Batch 1, issue #135): all six `deliver-*` skills take a minor bump (`deliver-prd` 2.1.0, `deliver-user-stories` 2.1.0, `deliver-acceptance-criteria` 1.1.0, `deliver-edge-cases` 2.1.0, `deliver-launch-checklist` 2.1.0, `deliver-release-notes` 2.1.0). Each gains a "When NOT to Use" section with boundary pointers to neighboring skills; five gain an Output Format that enumerates the template sections a complete artifact fills (acceptance-criteria already had one); one untestable checklist item rewritten (the release-notes tone check is now a verifiable jargon-leak check). HISTORY rows added, with first `HISTORY.md` files for prd, launch-checklist, and release-notes. No template or example changes.
 
 ### Fixed
 

--- a/docs/internal/release-plans/v2.26.0/implementation-plan_skill-quality-convergence.md
+++ b/docs/internal/release-plans/v2.26.0/implementation-plan_skill-quality-convergence.md
@@ -72,14 +72,14 @@ Create: `HISTORY.md` in each of those skill directories (none has one today).
 
 **Files:** `skills/{deliver-prd,deliver-user-stories,deliver-acceptance-criteria,deliver-edge-cases,deliver-launch-checklist,deliver-release-notes}/` (SKILL.md, references/TEMPLATE.md, references/EXAMPLE.md, HISTORY.md as needed). Branch: `chore/v2.26.0-f12-batch1`.
 
-- [ ] **Step 5.1 (triage calibration):** Run `utility-pm-skill-validate` on the five spec-named representative skills (deliver-prd, define-hypothesis, discover-competitive-analysis, measure-experiment-design, iterate-retrospective). First confirm the validate skill's CURRENT check list from its own SKILL.md (the brief's eight-check table may have drifted). Produce the triage table: per finding type, fix / skip / defer per the spec section 2 bar. Save the table into the PR description (not committed as a file).
-- [ ] **Step 5.2 (the per-skill loop, run for each of the 6 Deliver skills):**
+- [x] **Step 5.1 (triage calibration):** Run `utility-pm-skill-validate` on the five spec-named representative skills (deliver-prd, define-hypothesis, discover-competitive-analysis, measure-experiment-design, iterate-retrospective). First confirm the validate skill's CURRENT check list from its own SKILL.md (the brief's eight-check table may have drifted). Produce the triage table: per finding type, fix / skip / defer per the spec section 2 bar. Save the table into the PR description (not committed as a file).
+- [x] **Step 5.2 (the per-skill loop, run for each of the 6 Deliver skills):**
   1. `utility-pm-skill-validate <skill>` - capture findings.
   2. `utility-pm-skill-iterate <skill>` with the report - apply only section-2-bar fixes: add `## When NOT to Use` (with real boundary content, not boilerplate), enumerate template sections in the output contract, rewrite untestable checklist items, fill thin EXAMPLE sections.
   3. Bump `metadata.version` MINOR (2.0.1 -> 2.1.0 for Batch 0-touched skills; 2.0.0 -> 2.1.0 otherwise; deliver-acceptance-criteria 1.0.1 -> 1.1.0) + `metadata.updated`; add the HISTORY.md row (`minor | Quality convergence: When NOT to Use + output-contract tightening (F-12 Batch 1)`).
   4. Re-run `utility-pm-skill-validate <skill>` - zero FAIL, zero high-value WARN (AC-Q5).
-- [ ] **Step 5.3: Verify batch-wide.** `bash scripts/lint-skills-frontmatter.sh`; `bash scripts/validate-skill-history.sh`; `node scripts/check-emdash-scars.mjs`; `bash scripts/check-skill-cross-references.sh`; `bash scripts/check-count-consistency.sh` (counts unchanged, AC-Q6).
-- [ ] **Step 5.4:** CHANGELOG `[Unreleased]` entry (per-skill minor bumps named); push; PR `"feat: F-12 Batch 1 - Deliver cohort quality convergence (#135)"`; CI actual-conclusions check; squash-merge.
+- [x] **Step 5.3: Verify batch-wide.** `bash scripts/lint-skills-frontmatter.sh`; `bash scripts/validate-skill-history.sh`; `node scripts/check-emdash-scars.mjs`; `bash scripts/check-skill-cross-references.sh`; `bash scripts/check-count-consistency.sh` (counts unchanged, AC-Q6).
+- [x] **Step 5.4:** CHANGELOG `[Unreleased]` entry (per-skill minor bumps named); push; PR `"feat: F-12 Batch 1 - Deliver cohort quality convergence (#135)"`; CI actual-conclusions check; squash-merge.
 
 ### Tasks 6-8: Batches 2-4 (v2.26.x, after the v2.26.0 tag)
 

--- a/skills/deliver-acceptance-criteria/HISTORY.md
+++ b/skills/deliver-acceptance-criteria/HISTORY.md
@@ -2,8 +2,13 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 1.1.0 | 2026-06-10 | v2.26.0 | F-12-batch-1 | minor | Quality convergence: When NOT to Use section (F-12 Batch 1) |
 | 1.0.1 | 2026-06-10 | v2.26.0 | F-12-batch-0 | patch | Description rewrite for trigger accuracy (boundary disambiguation; 2026-06-09 audit, v2.26.0 Batch 0) |
 | 1.0.0 | 2026-03-22 | - | - | baseline | Prior published version |
+
+## 1.1.0 (2026-06-10)
+
+Quality-convergence minor (F-12 Batch 1): added a "When NOT to Use" section with boundary pointers to neighboring skills (the Output Contract already enumerated its groupings). No template or example changes.
 
 ## 1.0.1 (2026-06-10)
 

--- a/skills/deliver-acceptance-criteria/SKILL.md
+++ b/skills/deliver-acceptance-criteria/SKILL.md
@@ -4,7 +4,7 @@ description: Generates structured Given/When/Then acceptance criteria for a user
 license: Apache-2.0
 metadata:
   phase: deliver
-  version: "1.0.1"
+  version: "1.1.0"
   updated: 2026-06-10
   category: specification
   frameworks: [triple-diamond, lean-startup, design-thinking]
@@ -21,6 +21,13 @@ Acceptance criteria define the observable behavior that must be true for a story
 - When a team needs clear pass/fail conditions for implementation
 - When writing QA-ready criteria for sprint planning or handoff
 - When a story has edge cases, error paths, or non-functional expectations that should be explicit
+
+## When NOT to Use
+
+- You need the user stories themselves -> use `deliver-user-stories`; this skill deepens a story that already exists
+- You need systematic failure coverage across a whole feature -> use `deliver-edge-cases`; this skill stays story-scoped
+- There is no story or slice to bind criteria to yet -> use `deliver-prd` or `deliver-user-stories` first
+- You are defining success metrics for an experiment, not done-ness for a story -> use `measure-experiment-design`
 
 ## Instructions
 

--- a/skills/deliver-edge-cases/SKILL.md
+++ b/skills/deliver-edge-cases/SKILL.md
@@ -4,7 +4,7 @@ description: Documents edge cases, error states, boundary conditions, and recove
 license: Apache-2.0
 metadata:
   phase: deliver
-  version: "2.0.1"
+  version: "2.1.0"
   updated: 2026-06-10
   category: specification
   frameworks: [triple-diamond, lean-startup, design-thinking]
@@ -22,6 +22,13 @@ An edge cases document systematically catalogs the unusual, boundary, and error 
 - After discovering production bugs to prevent similar issues
 - When reviewing PRDs or user stories for completeness
 - Before launch to ensure error states have been designed
+
+## When NOT to Use
+
+- You need story-scoped Given/When/Then checks for handoff -> use `deliver-acceptance-criteria`; this skill catalogs the whole feature's failure surface
+- The feature is not specified enough to enumerate inputs, states, and limits -> use `deliver-prd` first
+- A production incident already happened and you want the learning banked -> use `iterate-lessons-log`, then update this catalog with the new case
+- You need readiness coordination for a launch, not failure analysis -> use `deliver-launch-checklist`
 
 ## Instructions
 
@@ -50,7 +57,7 @@ When asked to document edge cases, follow these steps:
 
 ## Output Format
 
-Use the template in `references/TEMPLATE.md` to structure the output.
+Use the template in `references/TEMPLATE.md` to structure the output. A complete edge-case catalog fills every template section: Feature Overview; Edge Case Categories; Error Messages; Recovery Paths; and Test Scenarios.
 
 ## Quality Checklist
 

--- a/skills/deliver-launch-checklist/HISTORY.md
+++ b/skills/deliver-launch-checklist/HISTORY.md
@@ -1,18 +1,13 @@
-# deliver-edge-cases - Version History
+# deliver-launch-checklist - Version History
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
 | 2.1.0 | 2026-06-10 | v2.26.0 | F-12-batch-1 | minor | Quality convergence: When NOT to Use + output-contract enumeration (F-12 Batch 1) |
-| 2.0.1 | 2026-06-10 | v2.26.0 | F-12-batch-0 | patch | Description rewrite for trigger accuracy (boundary disambiguation; 2026-06-09 audit, v2.26.0 Batch 0) |
 | 2.0.0 | 2026-01-26 | - | - | baseline | Prior published version |
 
 ## 2.1.0 (2026-06-10)
 
 Quality-convergence minor (F-12 Batch 1): added a "When NOT to Use" section with boundary pointers to neighboring skills, and the Output Format now enumerates the template sections a complete artifact fills. No template or example changes.
-
-## 2.0.1 (2026-06-10)
-
-Description-only patch (F-12 Batch 0, from the 2026-06-09 repo audit): the trigger-surface description was rewritten to disambiguate collision pairs with an explicit boundary pointer to the sibling skill. No body, template, or behavior changes.
 
 ## 2.0.0 (2026-01-26)
 

--- a/skills/deliver-launch-checklist/SKILL.md
+++ b/skills/deliver-launch-checklist/SKILL.md
@@ -4,8 +4,8 @@ description: Creates a comprehensive pre-launch checklist covering engineering, 
 license: Apache-2.0
 metadata:
   phase: deliver
-  version: "2.0.0"
-  updated: 2026-01-26
+  version: "2.1.0"
+  updated: 2026-06-10
   category: coordination
   frameworks: [triple-diamond, lean-startup, design-thinking]
   author: product-on-purpose
@@ -22,6 +22,13 @@ A launch checklist is a comprehensive verification document that ensures all fun
 - When coordinating cross-functional releases
 - Before major version releases or feature rollouts
 - After incidents to improve launch processes
+
+## When NOT to Use
+
+- You are validating whether to ship at all via an experiment -> use `measure-experiment-design`
+- You need the customer-facing announcement of what shipped -> use `deliver-release-notes`
+- The launch already happened and you want results or reflection -> use `measure-experiment-results` or `iterate-retrospective`
+- The change is small and single-team with no cross-functional surface: a launch checklist adds ceremony without value; track it in the sprint instead
 
 ## Instructions
 
@@ -50,7 +57,7 @@ When asked to create a launch checklist, follow these steps:
 
 ## Output Format
 
-Use the template in `references/TEMPLATE.md` to structure the output.
+Use the template in `references/TEMPLATE.md` to structure the output. A complete checklist fills every template section: Launch Overview; Engineering Readiness; QA & Testing; Design & UX; Marketing & Communications; Customer Support; Legal & Compliance; Operations & Infrastructure; Analytics & Monitoring; Go/No-Go Criteria; Rollback Plan; Check-in Schedule; and Open Issues.
 
 ## Quality Checklist
 

--- a/skills/deliver-prd/HISTORY.md
+++ b/skills/deliver-prd/HISTORY.md
@@ -1,18 +1,13 @@
-# deliver-edge-cases - Version History
+# deliver-prd - Version History
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
 | 2.1.0 | 2026-06-10 | v2.26.0 | F-12-batch-1 | minor | Quality convergence: When NOT to Use + output-contract enumeration (F-12 Batch 1) |
-| 2.0.1 | 2026-06-10 | v2.26.0 | F-12-batch-0 | patch | Description rewrite for trigger accuracy (boundary disambiguation; 2026-06-09 audit, v2.26.0 Batch 0) |
 | 2.0.0 | 2026-01-26 | - | - | baseline | Prior published version |
 
 ## 2.1.0 (2026-06-10)
 
 Quality-convergence minor (F-12 Batch 1): added a "When NOT to Use" section with boundary pointers to neighboring skills, and the Output Format now enumerates the template sections a complete artifact fills. No template or example changes.
-
-## 2.0.1 (2026-06-10)
-
-Description-only patch (F-12 Batch 0, from the 2026-06-09 repo audit): the trigger-surface description was rewritten to disambiguate collision pairs with an explicit boundary pointer to the sibling skill. No body, template, or behavior changes.
 
 ## 2.0.0 (2026-01-26)
 

--- a/skills/deliver-prd/SKILL.md
+++ b/skills/deliver-prd/SKILL.md
@@ -4,8 +4,8 @@ description: Creates a comprehensive Product Requirements Document that aligns s
 license: Apache-2.0
 metadata:
   phase: deliver
-  version: "2.0.0"
-  updated: 2026-01-26
+  version: "2.1.0"
+  updated: 2026-06-10
   category: specification
   frameworks: [triple-diamond, lean-startup, design-thinking]
   author: product-on-purpose
@@ -22,6 +22,13 @@ A Product Requirements Document is the primary specification artifact that commu
 - When multiple teams need to coordinate on a shared deliverable
 - When stakeholders need to approve scope before investment
 - As reference documentation during development and QA
+
+## When NOT to Use
+
+- The problem is still unframed or contested -> use `define-problem-statement` first; a PRD assumes an agreed problem
+- You need a one-page pitch to align stakeholders on an approach -> use `develop-solution-brief`; the PRD comes after that alignment
+- You only need the work broken into tickets for a sprint -> use `deliver-user-stories`
+- You are recording a technical or architectural decision -> use `develop-adr`
 
 ## Instructions
 
@@ -53,7 +60,7 @@ When asked to create a PRD, follow these steps:
 
 ## Output Format
 
-Use the template in `references/TEMPLATE.md` to structure the output.
+Use the template in `references/TEMPLATE.md` to structure the output. A complete PRD fills every template section: Overview; Goals & Success Metrics; User Stories; Scope; Solution Design; Technical Considerations; Dependencies & Risks; Timeline & Milestones; Open Questions; and the Appendix when supporting material exists.
 
 ## Quality Checklist
 

--- a/skills/deliver-release-notes/HISTORY.md
+++ b/skills/deliver-release-notes/HISTORY.md
@@ -1,18 +1,13 @@
-# deliver-edge-cases - Version History
+# deliver-release-notes - Version History
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
 | 2.1.0 | 2026-06-10 | v2.26.0 | F-12-batch-1 | minor | Quality convergence: When NOT to Use + output-contract enumeration (F-12 Batch 1) |
-| 2.0.1 | 2026-06-10 | v2.26.0 | F-12-batch-0 | patch | Description rewrite for trigger accuracy (boundary disambiguation; 2026-06-09 audit, v2.26.0 Batch 0) |
 | 2.0.0 | 2026-01-26 | - | - | baseline | Prior published version |
 
 ## 2.1.0 (2026-06-10)
 
 Quality-convergence minor (F-12 Batch 1): added a "When NOT to Use" section with boundary pointers to neighboring skills, and the Output Format now enumerates the template sections a complete artifact fills. No template or example changes.
-
-## 2.0.1 (2026-06-10)
-
-Description-only patch (F-12 Batch 0, from the 2026-06-09 repo audit): the trigger-surface description was rewritten to disambiguate collision pairs with an explicit boundary pointer to the sibling skill. No body, template, or behavior changes.
 
 ## 2.0.0 (2026-01-26)
 

--- a/skills/deliver-release-notes/SKILL.md
+++ b/skills/deliver-release-notes/SKILL.md
@@ -4,8 +4,8 @@ description: Creates user-facing release notes that communicate new features, im
 license: Apache-2.0
 metadata:
   phase: deliver
-  version: "2.0.0"
-  updated: 2026-01-26
+  version: "2.1.0"
+  updated: 2026-06-10
   category: coordination
   frameworks: [triple-diamond, lean-startup, design-thinking]
   author: product-on-purpose
@@ -22,6 +22,13 @@ Release notes communicate product changes to users in a way that highlights valu
 - Preparing app store update descriptions
 - Writing customer-facing email announcements
 - Documenting changes for support and sales teams
+
+## When NOT to Use
+
+- You are updating internal stakeholders on progress rather than announcing shipped changes -> use `foundation-stakeholder-update`
+- You need the technical record of changes for developers -> keep the engineering changelog; this skill translates changes into user benefits
+- You are coordinating launch readiness rather than communicating the ship -> use `deliver-launch-checklist`
+- Nothing user-visible shipped (a pure internal refactor): release notes that stretch to find a benefit erode trust; skip the cycle or fold it into the next one
 
 ## Instructions
 
@@ -50,7 +57,7 @@ When asked to create release notes, follow these steps:
 
 ## Output Format
 
-Use the template in `references/TEMPLATE.md` to structure the output.
+Use the template in `references/TEMPLATE.md` to structure the output. Complete release notes fill the template sections: Highlights; New Features; Improvements; Bug Fixes; Known Issues; Coming Soon (optional); and Feedback.
 
 ## Quality Checklist
 
@@ -61,7 +68,7 @@ Before finalizing, verify:
 - [ ] Language is jargon-free and accessible to all users
 - [ ] Items are concise (1-2 sentences each)
 - [ ] Bug fixes mention the problem that was solved
-- [ ] Tone is positive and professional
+- [ ] No internal jargon, ticket IDs, or code names leak through; every line reads as customer-facing
 
 ## Examples
 

--- a/skills/deliver-user-stories/HISTORY.md
+++ b/skills/deliver-user-stories/HISTORY.md
@@ -2,8 +2,13 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 2.1.0 | 2026-06-10 | v2.26.0 | F-12-batch-1 | minor | Quality convergence: When NOT to Use + output-contract enumeration (F-12 Batch 1) |
 | 2.0.1 | 2026-06-10 | v2.26.0 | F-12-batch-0 | patch | Description rewrite for trigger accuracy (boundary disambiguation; 2026-06-09 audit, v2.26.0 Batch 0) |
 | 2.0.0 | 2026-01-26 | - | - | baseline | Prior published version |
+
+## 2.1.0 (2026-06-10)
+
+Quality-convergence minor (F-12 Batch 1): added a "When NOT to Use" section with boundary pointers to neighboring skills, and the Output Format now enumerates the template sections a complete artifact fills. No template or example changes.
 
 ## 2.0.1 (2026-06-10)
 

--- a/skills/deliver-user-stories/SKILL.md
+++ b/skills/deliver-user-stories/SKILL.md
@@ -4,7 +4,7 @@ description: Generates user stories in the standard persona, action, benefit sto
 license: Apache-2.0
 metadata:
   phase: deliver
-  version: "2.0.1"
+  version: "2.1.0"
   updated: 2026-06-10
   category: specification
   frameworks: [triple-diamond, lean-startup, design-thinking]
@@ -22,6 +22,13 @@ User stories are concise descriptions of functionality from the user's perspecti
 - When writing tickets for engineering teams
 - When communicating requirements to stakeholders in accessible terms
 - When prioritizing a backlog based on user value
+
+## When NOT to Use
+
+- You need deeper, QA-ready Given/When/Then coverage for a single story or slice -> use `deliver-acceptance-criteria`
+- You need the feature-wide catalog of boundary conditions and failure scenarios -> use `deliver-edge-cases`
+- The feature itself is not yet specified -> use `deliver-prd` first; stories should trace back to documented requirements
+- You want refinement-session outcomes (estimates, scope decisions, open questions) -> use `iterate-refinement-notes`
 
 ## Instructions
 
@@ -50,7 +57,7 @@ When asked to create user stories, follow these steps:
 
 ## Output Format
 
-Use the template in `references/TEMPLATE.md` to structure the output.
+Use the template in `references/TEMPLATE.md` to structure the output. A complete output carries, per story: Story Header; User Story Statement; Context & Background; Acceptance Criteria; Design Notes; Technical Notes; Dependencies; Out of Scope; and Open Questions where any remain. Multi-story documents nest these sections under one heading per story, as the example shows.
 
 ## Quality Checklist
 

--- a/skills/utility-pm-skill-builder/SKILL.md
+++ b/skills/utility-pm-skill-builder/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 # PM Skill Builder
 
 This skill creates new PM skills for the pm-skills library. It produces a
-Skill Implementation Packet - a complete design document with draft files .
+Skill Implementation Packet - a complete design document with draft files
 in a staging area for review before promotion to canonical locations.
 
 ## When to Use


### PR DESCRIPTION
## What

STEP 4 of the v2.26.0 build: F-12 Batch 1 per [implementation-plan_skill-quality-convergence.md](https://github.com/product-on-purpose/pm-skills/blob/main/docs/internal/release-plans/v2.26.0/implementation-plan_skill-quality-convergence.md) Task 5.

### Triage calibration (Task 5.1, five representative skills)
Validated deliver-prd, define-hypothesis, discover-competitive-analysis, measure-experiment-design, iterate-retrospective against `utility-pm-skill-validate`'s current check list (confirmed from its SKILL.md; note: its Tier-1 `command-exists` check predates the v2.22.0 wrapper removal, follow-up candidate). Identical fingerprint on all five:

| Finding (validator check) | Prevalence | Disposition per spec section 2 |
|---|---|---|
| `when-not-to-use` missing (INFO) | 5/5 | FIX: adopt, minor bump |
| `output-contract-coverage`: defers wholesale to template | 5/5 | FIX: enumerate template sections |
| `checklist-verifiability`: occasional subjective item | 2/5 | FIX where genuinely vague |
| `example-completeness` / `template-example-alignment` | 0/5 | no findings (user-stories' EXAMPLE legitimately nests per-story; accepted) |
| `description-actionability`, `instruction-clarity`, `placeholder-leakage` | 0/5 | PASS (Batch 0 fixed descriptions) |

### Per-skill loop (Task 5.2, the six deliver-* skills)
Each: validate -> apply the three-edit pattern -> minor bump + HISTORY -> re-validate (zero FAIL, zero high-value WARN; AC-Q5):
- **When NOT to Use** with real boundary pointers (every named neighbor exists; AC-Q2 re-checked)
- **Output Format enumerates the template sections** (5 skills; `deliver-acceptance-criteria` already had an enumerated Output Contract, so it takes only the section + bump)
- `deliver-release-notes`' subjective 'tone is positive and professional' checklist item rewritten as a verifiable jargon/ticket-ID leak check
- Bumps: prd / user-stories / edge-cases / launch-checklist / release-notes -> 2.1.0; acceptance-criteria -> 1.1.0. First HISTORY.md for prd, launch-checklist, release-notes; rows appended for the Batch-0-touched three (spec D-3 double-bump accepted)

### Adjacent hygiene
One cross-line spaced-period scar in `utility-pm-skill-builder` (line-end ' .' the line-based guard cannot see) removed.

## Verification
- lint-skills-frontmatter, validate-skill-history (all 6 current versions present, no warnings), scar guard, cross-references, count-consistency: PASS
- Full pre-tag bundle ALL CHECKS PASSED in both shells; resource index regenerated and current

Part of #135 (Batches 2-4 follow as v2.26.x patches; the issue stays open).