### PR TITLE
ci: run validate-plugin on every PR so the required check can report

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -1,16 +1,16 @@
 name: Validate Plugin Packaging
 
 on:
+  # No `paths:` filter on pull_request, deliberately. `validate-plugin` is a
+  # REQUIRED status check in the `main Protection` ruleset. A required check that
+  # never reports leaves the PR permanently BLOCKED, with every visible check
+  # green and no failure to point at. A paths filter here deadlocked every
+  # site-only and root-package-only PR opened after 2026-07-05, including eight
+  # Dependabot PRs carrying open security alerts. The job runs in about 20
+  # seconds; running it on every PR costs far less than the deadlock.
+  # Do not add a paths filter here without first removing `validate-plugin` from
+  # the ruleset's required status checks.
   pull_request:
-    paths:
-      - ".claude-plugin/**"
-      - ".codex-plugin/**"
-      - "skills/**"
-      - "commands/**"
-      - "scripts/build-release.sh"
-      - "scripts/build-release.ps1"
-      - ".github/workflows/validate-plugin.yml"
-      - ".github/workflows/release.yml"
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

`validate-plugin` is one of three required status checks in the `main Protection` ruleset, alongside `validate (ubuntu-latest)` and `validate (windows-latest)`. But its `pull_request` trigger carried a `paths:` filter limited to `.claude-plugin/**`, `.codex-plugin/**`, `skills/**`, `commands/**`, `scripts/build-release.*`, `validate-plugin.yml`, and `release.yml`.

A PR touching only `site/**` or a root `package.json` never triggers the workflow. The required check therefore never reports a conclusion, and GitHub returns `mergeStateStatus: BLOCKED` permanently, with every visible check green and no failure to point at.

## Evidence

- The only two currently `CLEAN` PRs (#239, #211) both edit `.github/workflows/validate-plugin.yml`, which is on the filter list. Every `BLOCKED` PR is missing that check entirely.
- The last four site-only merges (#222, #213, #210, #206) landed in a 17-second burst at `2026-07-05T16:40:59Z` through `16:41:16Z`, starting 53 seconds after the ruleset's last recorded edit at `2026-07-05T16:40:06Z`. Nothing site-only has merged since.
- Nine open PRs are affected. Eight are Dependabot updates carrying open security alerts, four of them high severity.

## Fix

Drop the `paths:` filter from the `pull_request` trigger so the required check always reports. The job runs in about 20 seconds, so this costs far less than the deadlock, and it makes the required-check guarantee genuinely enforced rather than conditionally skipped.

The `push` trigger keeps its filter unchanged, since required-check evaluation applies only to pull requests.

A comment is added at the trigger explaining the constraint, so the filter is not restored later without first removing `validate-plugin` from the ruleset's required checks.

## Verification

This PR edits `validate-plugin.yml`, which was on the old filter list, so `validate-plugin` runs here under both the old and new configuration. Green checks on this PR confirm the workflow still passes; the real proof of the fix is that the next site-only PR reports the check.
