### PR TITLE
ci: fix nondeterministic false failure in the bash AGENTS.md sync validator

### DIFF
--- a/scripts/validate-agents-md.sh
+++ b/scripts/validate-agents-md.sh
@@ -28,8 +28,23 @@ skill_paths=("${_sorted[@]}")
 agents_paths=()
 while IFS= read -r _line; do agents_paths+=("$_line"); done < <(grep -oE 'skills/[a-z0-9-]+/SKILL\.md' "$AGENTS" | sort -u)
 
+# Pure-bash membership test, deliberately NOT `printf ... | grep -Fxq`. Under the
+# `set -o pipefail` above, that idiom is nondeterministically WRONG: `grep -q`
+# exits the moment it matches, closing the read end, so `printf` can die with
+# EPIPE ("write error: Broken pipe"). pipefail then promotes the dead printf to a
+# pipeline failure even though grep matched, and the entry is falsely reported
+# missing. It surfaced on main 2026-07-30, failing on two skills whose entries
+# were present, while the PowerShell leg passed on identical content. No pipe,
+# no race. Kept bash 3.2 compatible (no associative arrays).
 for path in "${skill_paths[@]}"; do
-  if ! printf '%s\n' "${agents_paths[@]}" | grep -Fxq "$path"; then
+  found=0
+  for entry in "${agents_paths[@]}"; do
+    if [[ "$entry" == "$path" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ $found -eq 0 ]]; then
     echo "FAIL: AGENTS.md missing entry for $path"
     FAIL=1
   fi


### PR DESCRIPTION
## Problem

`scripts/validate-agents-md.sh` sets `set -euo pipefail` (line 2) and tested membership with:

```bash
if ! printf '%s\n' "${agents_paths[@]}" | grep -Fxq "$path"; then
```

`grep -q` exits the instant it matches, closing the read end of the pipe, so `printf` can die with `EPIPE`. Under `pipefail` that dead `printf` becomes the pipeline's exit status even though grep matched, and the loop reports a present entry as missing.

## How it surfaced

It is a race, so it stayed hidden for a long time: 14 consecutive `main` runs passed, and the same tree passed on its own PR minutes earlier. It fired on `main` at `c33e5f2d`:

```
scripts/validate-agents-md.sh: line 32: printf: write error: Broken pipe
FAIL: AGENTS.md missing entry for skills/define-jtbd-canvas/SKILL.md
scripts/validate-agents-md.sh: line 32: printf: write error: Broken pipe
FAIL: AGENTS.md missing entry for skills/define-problem-statement/SKILL.md
```

Both entries are present in `AGENTS.md`, and `validate (windows-latest)` passed on identical content. The two shells disagreed on a repo that was correct.

## Fix

A pure-bash membership loop. No pipe, no race, still bash 3.2 compatible (no associative arrays), and the failure message is unchanged.

## Verification

Both directions checked locally, because a validator that can no longer fail would be worse than a flaky one:

- **Positive:** `OK: AGENTS.md matches 68 skill paths` / `OK: AGENTS.md references 6 sub-agents`, exit 0.
- **Negative:** with one entry removed, `FAIL: AGENTS.md missing entry for skills/define-jtbd-canvas/SKILL.md`, exit 1.

## Related, deliberately not changed

The same idiom appears in `scripts/lint-skills-frontmatter.sh`, which also sets `pipefail`. Its piped producers are a single frontmatter block rather than a 68-entry array, so the window is far smaller and it has never been observed to fire. Surveyed the other `printf | grep -q` sites too: `check-skill-cross-references.sh`, `validate-meeting-skills-family.sh`, `validate-codex-manifest.sh` and `check-version-references.sh` do **not** set `pipefail`, so SIGPIPE there is harmless.
