### PR TITLE
fix(deps): bump transitive js-yaml to 3.15.0 in .github/scripts

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Closes the final two open Dependabot alerts - #40 (high) and #31 (medium). `js-yaml@3.14.2` is transitive via `gray-matter@^4.0.3`, whose `^3.13.1` range already permits the patched 3.15.0, so this is a lockfile-only `npm update js-yaml`. No Dependabot PR existed because the dependency is transitive. 3.15.0 backports the `maxTotalMergeKeys` hardening for YAML merge-key processing.