### PR TITLE
fix(skills): two field-reported defects - persona example conformance and prioritization calibration

### DIFF
--- a/skill-manifest.json
+++ b/skill-manifest.json
@@ -420,7 +420,7 @@
     {
       "name": "foundation-persona",
       "description": "Generates an evidence-calibrated product or marketing persona using the canonical v2.5 output contract. Use when shaping artifact perspective, stress-testing decisions, or framing product and GTM strategy.",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "group": "foundation",
       "phase": null,
       "family": null,

--- a/skill-manifest.json
+++ b/skill-manifest.json
@@ -60,7 +60,7 @@
     {
       "name": "define-prioritization-framework",
       "description": "Run applicable prioritization frameworks (RICE, ICE, MoSCoW, Weighted Scoring, Kano) against a list of features or initiatives. Produces a comparison table showing where rankings agree and diverge across frameworks, and an executive summary with recommendation. Framework applicability is filtered by data availability; Kano requires customer research. Refuses to fabricate scores; produces an estimation scaffold when input data is missing.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "group": "phase",
       "phase": "define",
       "family": null,

--- a/skills/define-prioritization-framework/HISTORY.md
+++ b/skills/define-prioritization-framework/HISTORY.md
@@ -2,9 +2,22 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 1.3.0 | 2026-08-16 | v2.33.0 | C-14 | minor | Field-reported calibration (#252): top/bottom highlight rule scales below 10 items, RICE Effort unit scales to real team capacity, Kano gains surveyed and inferred evidence tiers. |
 | 1.2.0 | 2026-07-05 | v2.31.0 | WS-Z5 | minor | Reciprocal When NOT to Use pointer to `foundation-prioritized-action-plan`; collision pair declared with new trigger fixtures. |
 | 1.1.0 | 2026-07-04 | v2.30.0 | M-35 | minor | Added a "When NOT to Use" section with five reciprocal boundary pointers, including the bidirectional edge back to `define-opportunity-tree` (which already pointed here). Closes a one-way gap in the cross-skill reciprocity mesh flagged by the 2026-07-04 deep audit. Also normalized the "Output format" and "Quality checklist" headings to their canon spelling and resolved a phantom `deliver-roadmap` pointer in Cross-skill composition (both WS-T8b/f, no re-bump). |
 | 1.0.0 | 2026-05-21 | v2.18.0 | - | baseline | Prior published version: runs the applicable prioritization frameworks (RICE, ICE, MoSCoW, Weighted Scoring, Kano) against a candidate list, filtered by data availability, surfacing where rankings agree and diverge plus an executive recommendation. |
+
+## 1.3.0 (2026-08-16)
+
+Field-reported calibration ([#252](https://github.com/product-on-purpose/pm-skills/issues/252)), from an end-to-end run on a real 8-item backlog in a solo-maintainer context. The report was positive about the skill overall and singled out the convergence and divergence analysis as its most valuable output, so these are calibration fixes rather than defect repairs.
+
+**Top and bottom highlight rule now scales below 10 items.** The rule read "highlight the top 5 and bottom 5"; with 8 items, 5 and 5 overlap or exhaust the list and the rule cannot be followed as written. At 10 or fewer items the skill now shows every item in rank order and describes the gap between clear tiers instead of forcing a five-and-five split.
+
+**RICE Effort unit now scales to real team capacity.** The unit was fixed as eng-weeks or person-weeks. For a solo operator with roughly five hours a week, a notional 40-hour week makes every small item round to "under one week" and the Effort dimension stops discriminating entirely. The unit is now capacity-weeks, sized to what a week actually buys that team, with the conversion stated in the output.
+
+**Kano gains explicit evidence tiers.** The applicability gate asked for "customer-research input" without saying whether summarized signals qualified or whether formal Kano question pairs were required. It now distinguishes a surveyed tier (functional and dysfunctional pairs per feature, classify normally) from an inferred tier (interview themes, survey means, support patterns; classify, label as inferred, and treat a Delighter or Must-Have call as a hypothesis to confirm). Refusal is reserved for having no customer research at all, since downgrading the tier and saying so is more useful than excluding the framework.
+
+Minor rather than patch: the Kano tiering lets the skill run a case it previously refused or fudged, and adds an optional tier label to the output, which is additive behavior under the versioning tie-breaker.
 
 ## 1.2.0 (2026-07-05)
 

--- a/skills/define-prioritization-framework/SKILL.md
+++ b/skills/define-prioritization-framework/SKILL.md
@@ -4,7 +4,7 @@ description: Run applicable prioritization frameworks (RICE, ICE, MoSCoW, Weight
 license: Apache-2.0
 metadata:
   phase: define
-  version: "1.2.0"
+  version: "1.3.0"
   updated: 2026-07-05
   category: planning
   frameworks: [triple-diamond, prioritization]
@@ -62,7 +62,7 @@ Before running, evaluate each framework against the available inputs. Run all fr
 | **ICE** (Impact * Confidence * Ease) | Always applicable; coarse estimates are acceptable | Not excluded; ICE is the lowest-input framework |
 | **MoSCoW** (Must / Should / Could / Won't) | Decision involves binary commitment per item or scope bounding | Not applicable for pure ranking decisions without scope constraint |
 | **Weighted Scoring** (multi-criteria with weights) | Multiple stakeholders or criteria apply; user provides or accepts proposed default weights | Single criterion dominates; or criteria are purely personal preference |
-| **Kano** (Must-Have / Performance / Delighter) | Customer-research input (survey or interview data) is provided | **Gated:** excluded if no customer research is provided; explain why and suggest what research would unlock it |
+| **Kano** (Must-Have / Performance / Delighter) | Customer-research input is provided, at either evidence tier below | **Gated:** excluded only if no customer research at all is provided; explain why and suggest what research would unlock it. Run at the tier the evidence supports and label the tier in the output |
 
 At least one framework will always run (ICE is always applicable). Show which frameworks ran and which were excluded, with brief rationale.
 
@@ -82,7 +82,7 @@ Run each applicable framework and produce its scoring table.
 
 **For RICE:**
 
-| Item | Reach (users/qtr) | Impact (0.25-3) | Confidence (%) | Effort (eng-weeks) | RICE Score | Notes |
+| Item | Reach (users/qtr) | Impact (0.25-3) | Confidence (%) | Effort (capacity-weeks) | RICE Score | Notes |
 |---|---|---|---|---|---|---|
 | Item A | 1000 | 2 | 80% | 3 | 533 | High confidence on reach |
 
@@ -109,7 +109,7 @@ Run each applicable framework and produce its scoring table.
 
 ### 4. Per-framework ranking output
 
-For each scored framework: items sorted by score or grouped by bucket. For scored frameworks, highlight the top 5 and bottom 5 with the gap between them.
+For each scored framework: items sorted by score or grouped by bucket. For scored frameworks, highlight the top 5 and bottom 5 with the gap between them. **When the backlog has 10 or fewer items**, a top 5 and a bottom 5 overlap or exhaust the list, so the rule cannot be followed as written: show every item in rank order instead and describe the gap between the clear tiers rather than forcing a five-and-five split.
 
 ### 5. Cross-framework comparison
 
@@ -163,7 +163,7 @@ You refuse to produce a ranking without minimum input quality. Specifically:
 - Reach: how many users / customers / events affected per time period (per quarter is common). Number, not %.
 - Impact: how much each affected user benefits. Use Intercom's scale: 0.25 (minimal), 0.5 (low), 1 (medium), 2 (high), 3 (massive).
 - Confidence: how sure you are about the other estimates. 0-100%.
-- Effort: how much work it takes in eng-weeks (or person-weeks). Higher = lower score.
+- Effort: how much work it takes in capacity-weeks. Higher = lower score. **Scale the unit to the executing team's real weekly capacity and state the conversion in the output.** A notional 40-hour engineering week is the right unit for a staffed team and the wrong one for a solo maintainer with five hours a week: at that capacity every small item rounds to "under one week" and the Effort dimension stops discriminating between items entirely. Size in whatever a week actually buys that team, name the unit once, and keep it consistent across all items.
 
 ### ICE (Impact, Confidence, Ease)
 
@@ -200,7 +200,16 @@ Categorize features by how their presence / absence affects customer satisfactio
 - Reverse: presence dissatisfies (rare)
 - Indifferent: customers do not care either way
 
-Requires customer-research input (survey or interview) to populate categories defensibly. **Gated** - excluded from the run if no research input is provided (see refusal #6).
+Requires customer-research input to populate categories defensibly. **Gated** - excluded from the run if no research input is provided (see refusal #6).
+
+**Evidence tiers, because "customer research" spans a wide range and the classification's trustworthiness varies with it.** State which tier the run used, in the output, next to the categories:
+
+| Tier | What it means | How to run and label |
+|---|---|---|
+| **Surveyed** | Formal Kano question pairs, functional and dysfunctional, asked per feature | Classify normally. Label **Kano (surveyed)**. Categories are directly measured |
+| **Inferred** | Summarized research: interview themes, survey means, support-ticket patterns, or analytics that speak to satisfaction but were not collected as Kano pairs | Classify, and label **Kano (inferred)**. Say which signal drove each non-obvious category, and treat a Delighter or Must-Have call as a hypothesis to confirm rather than a finding |
+
+Do not refuse a run because the evidence is inferred rather than surveyed. Refuse only when there is no customer research at all. Downgrading to the inferred tier and saying so is more useful than excluding the framework, and it keeps the confidence claim honest.
 
 ## Cross-skill composition
 

--- a/skills/foundation-persona/HISTORY.md
+++ b/skills/foundation-persona/HISTORY.md
@@ -2,8 +2,19 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 2.6.1 | 2026-08-16 | v2.33.0 | C-14 | patch | EXAMPLE.md regenerated against the shipped TEMPLATE; the two had demonstrated different formats (#251) |
 | 2.6.0 | 2026-06-10 | v2.26.0 | F-12-batch-4 | minor | Quality convergence: When NOT to Use section (F-12 Batch 4) |
 | 2.5.0 | 2026-03-02 | - | - | baseline | Prior published version |
+
+## 2.6.1 (2026-08-16)
+
+Field-reported fix ([#251](https://github.com/product-on-purpose/pm-skills/issues/251), found during an end-to-end run on a real product).
+
+`references/EXAMPLE.md` demonstrated a "Layer 1: Narrative Persona Dossier / Layer 2: Operational Appendix" structure whose sections (`Opening scene`, `What they say vs what they mean`, `Completeness Floors`) appear nowhere in `references/TEMPLATE.md`. An agent loading both references got two canonical formats with no signal which one wins. The reporter's own run resolved it correctly by following SKILL.md's pointer to the Output Contract, but that resolution costs tokens and a weaker model could plausibly ship the non-conforming format and silently violate the contract that downstream skills consume.
+
+EXAMPLE.md is now a filled-in instance of the Product Persona Template, verified section-for-section against it: all 13 template sections present, none added, no authoring blockquotes leaked, no unfilled placeholders. It also gains the YAML frontmatter every other skill's example carries and previously lacked.
+
+The persona itself is preserved rather than replaced. Rhea Patel, the regulated approval-chain owner, was re-rendered into the mandated structure, so the authored substance survives the format correction. Patch rather than minor: the required contract is unchanged and only the example was brought into line with it, per the `examples improved` row of the versioning table.
 
 ## 2.6.0 (2026-06-10)
 

--- a/skills/foundation-persona/SKILL.md
+++ b/skills/foundation-persona/SKILL.md
@@ -4,7 +4,7 @@ description: Generates an evidence-calibrated product or marketing persona using
 license: Apache-2.0
 metadata:
   classification: foundation
-  version: "2.6.0"
+  version: "2.6.1"
   updated: 2026-06-10
   category: research
   frameworks: [triple-diamond, lean-startup, design-thinking]

--- a/skills/foundation-persona/references/EXAMPLE.md
+++ b/skills/foundation-persona/references/EXAMPLE.md
@@ -1,152 +1,222 @@
-# Persona Dossier: Rhea Patel, Keeper of the Approval Chain (Product)
+---
+artifact: foundation-persona
+version: "2.0"
+created: 2026-08-16
+status: complete
+mode: product
+context: Regulated B2B workflow software. Clinical quality operations lead who owns the approval chain, built from 5 interviews plus support-ticket and audit-log review.
+---
 
-## Layer 1: Narrative Persona Dossier
+# Rhea Patel - Keeper of the Approval Chain
 
-## Executive summary
-- Rhea optimizes for defensible execution, not superficial speed.
-- She blocks ambiguous high-impact approvals because late discovery is costlier than early friction.
-- Approval quality is a product surface, not just an operational policy.
-- Exception handling is acceptable only when ownership, reason, expiry, and follow-up are explicit.
-- Teams misread her as conservative when they do not carry downstream accountability.
-- She needs fast decision-quality signals, not verbose status reporting.
-- Contradictory approvals and stale evidence links are top trust-breakers.
-- "Green" status without rationale is functionally a false positive.
-- She values controlled acceleration during deadlines, not process rigidity.
-- Products that preserve legibility under pressure earn sustained sponsorship.
+**Rhea owns the final approval gate in a regulated workflow, which means every shortcut taken upstream becomes her liability downstream, and she would rather absorb friction now than reconstruct a decision under audit six months later.**
 
-### 1) Opening scene
-At 5:37 PM on submission day, the package is marked ready and Slack is celebrating a green status. Rhea opens the final approval thread and finds one high-impact approval with no rationale and one unresolved exception with no owner.
+| Field | Value |
+| --- | --- |
+| Persona ID | PU-004 |
+| Type | Primary |
+| Product scope | Approval workflows, exception handling, evidence and audit surfaces |
+| Valid for | Quality and compliance operations leads at 200-2000 person regulated companies, where approvals carry legal or patient-safety consequence |
+| Not valid for | Individual reviewers who approve within their own scope, and consumer or low-stakes internal approvals with no audit obligation |
+| Confidence | Directional. Five interviews plus support and audit-log review; behavioral model is consistent, quantitative baselines are missing |
+| Last validated | 2026-08-16 |
+| Owner | Product, Workflow and Compliance area |
 
-She pauses release.
-
-To other teams this looks like delay; to Rhea it is risk containment before cost multiplies downstream.
-
-### 2) Who this person is when work gets real
-Rhea runs Clinical Quality Operations in a regulated environment where "done" has legal and operational consequences. She is collaborative and practical, but she has one hard boundary: if a high-risk decision cannot be explained later, the process is not trustworthy.
-
-She does not optimize for workflow aesthetics. She optimizes for outcomes that survive scrutiny.
-
-### 3) Core tension and decision model
-Rhea is not "quality over speed." She is anti-fragile speed. Her operating question is not "how quickly did we ship" but "how many hidden assumptions did we carry to the finish line."
-
-When information is incomplete, she chooses early clarification over late-stage narrative reconstruction.
-
-### 4) Decision moments that define behavior
-- Decision moment A: If evidence is incomplete and accountability is unclear, block and clarify now.
-- Decision moment B: Allow lightweight approval for low-risk edits, but require rationale and confidence for high-impact changes.
-- Decision moment C: Permit scoped exceptions under deadline only when owner, reason, expiry, and follow-up criteria are explicit.
-
-### 5) What they say vs what they mean
-| What they say | What they mean | Product implication |
-|---|---|---|
-| "This feels brittle." | A single dependency failure can cascade silently. | Surface dependency and handoff risk early. |
-| "Can we stand behind this?" | Current pass state will fail under scrutiny later. | Require rationale and confidence for high-impact claims. |
-| "Who owns this?" | Accountability is ambiguous right now. | Make ownership explicit in approval and exception flows. |
-| "We are not ready." | It can pass today but fail in review tomorrow. | Align pre-flight and final-gate validation logic. |
-
-### 6) Operating modes
-- Normal mode: prioritize throughput while preserving traceability.
-- Compression mode: prioritize controlled acceleration with risk summaries and explicit exception governance.
-- Incident mode: prioritize containment, provenance reconstruction, and clear owner/action mapping.
-
-### 7) Product strategy implications
-Priority stack:
-- Decision-quality signals (confidence, rationale, impact cues)
-- Exception governance (owner, reason, expiry, follow-up)
-- Validation parity (same rules in flow and export)
-- Conflict visibility (contradictory approvals, stale references)
-- Human-readable policy explanations (what failed, why, what next)
-
-Anti-patterns to avoid:
-- Green states that hide unresolved uncertainty
-- Approval models that flatten low-risk and high-risk decisions into one flow
-
-### 8) Design principles this persona forces
-- Never show "green" when critical uncertainty is unresolved.
-- Treat approval quality as a first-class UX problem.
-- Design reversible, auditable exception paths.
-- Separate low-risk convenience from high-risk control boundaries.
-- Optimize for cross-role clarity, not only individual speed.
-
-### 9) If this persona wins, what changes?
-Teams stop shipping convenience features that collapse under pressure and start shipping systems that remain legible during deadlines, disagreement, and audit. Velocity stays high, but avoidable rework and accountability gaps decline materially.
+**Quick orientation.** The Persona Card is the daily-use reference. Sections 1-4 provide context and motivation. Sections 5-8 describe behavior and workflow. Sections 9-11 translate insight into product decisions. Evidence and Confidence calibrates trust.
 
 ---
 
-## Layer 2: Operational Appendix
+## Persona Card
 
-### A) Request Context
-- **Mode:** product
-- **Mode alias used:** none
-- **Detail profile:** detailed
-- **Artifact or task context:** improve a regulated approval workflow for `problem-statement`, `prd`, and `edge-cases`
-- **Domain context:** regulated B2B workflow software
+**Rhea Patel - Keeper of the Approval Chain**
+Rhea runs clinical quality operations and holds the last signature before a submission package ships. She serves the reviewers upstream of her and the auditors downstream, and she is the person who gets asked, months later, why a decision was made. Her relationship with the product is defined by that asymmetry: everyone else is optimizing for today, and she is answering for it later.
 
-### B) Depth Guidance
-- **Product detailed:** ~350-900 lines (soft target)
-- **Marketing detailed:** ~340-850 lines (soft target)
-- **Brief profile (either mode):** ~170-360 lines (soft target)
-- **Brief profile:** prioritize decision snapshot and immediate actions
-- **Detailed profile:** include richer tradeoffs, constraints, and edge conditions
-- **If user asks comprehensive/best-in-class:** target upper half of selected range
+**Key quote:** "I do not need it to be fast. I need to be able to stand behind it in a year when nobody remembers the context."
 
-### C) Completeness Floors (Soft)
-- **Product detailed:** 8+ substantive sections, 2+ tables/matrices, 5+ scenario-tailoring entries
-- **Marketing detailed:** 8+ substantive sections, 2+ tables/matrices, 4+ scenario-tailoring entries
-- **Brief profile:** 6-10 executive-summary bullets and 3+ scenario-tailoring entries
-- **All outputs:** sections must be decision-usable; do not ship placeholder-level bullets
+**Goals.** Ship on time without carrying hidden assumptions past the gate. Make accountability legible so exceptions do not become orphans. Reconstruct any decision quickly when it is questioned. Spend her scarce attention on the few approvals that actually carry risk.
 
-### D) Includes / Excludes
-- **Includes:** workflow friction, decision triggers, risk posture, product tradeoff direction
-- **Excludes:** campaign messaging strategy, channel planning, non-decision persona trivia
+**Frustrations.** A green status that hides unresolved uncertainty. High-impact approvals recorded with no rationale. Exceptions granted under deadline with no owner or expiry. Evidence links that have gone stale since the approval. Being read as an obstacle by people who will not be in the room for the audit.
 
-### E) Scenario tailoring
-- For `problem-statement`: frame the issue as late discovery and hidden ambiguity in high-stakes approvals.
-- For `prd`: require explicit requirements for rationale capture, exception lifecycle ownership, and validation parity.
-- For `user-stories`: encode accountability semantics (who decides, required evidence, conflict handling, recoverable failure).
-- For `edge-cases`: prioritize contradictory approvals, stale evidence links, ownerless exceptions, and deadline overrides without rationale.
-- For `launch-checklist`: include reviewer enablement, escalation ownership coverage, and rollback readiness for approval-logic regressions.
+**Design rules - always.** Show why something passed, not just that it passed. Make ownership explicit at the moment an exception is created. Apply the same validation rules in the working flow and in the exported package.
 
-### F) When not to use this persona
-- Do not use for top-of-funnel demand generation strategy.
-- Do not use for consumer UX polish work with no compliance or audit consequence.
-- Do not use for pure brand storytelling disconnected from workflow risk.
+**Design rules - never.** Never flatten low-risk and high-risk approvals into one undifferentiated flow. Never display an aggregate green state while a critical item is unresolved. Never let a deadline override remove the requirement to record a reason.
 
-### G) Assumptions and Confidence
-- **Key assumptions:**
-  - Cross-functional approvals are a core business path.
-  - Decision provenance is required for audits and escalations.
-  - Late-stage rework is materially costly.
-  - Reviewer quality is variable under deadline pressure.
-- **Confidence:** Medium
-- **Confidence rationale:** Strong behavioral fit for regulated operations leadership, but weighting should be calibrated with current baseline metrics.
+---
 
-## Evidence Trail
+## 1. Demographics & Identity
 
-### User-provided inputs
-| ID | Resource | Type | Used for | Notes |
-|---|---|---|---|---|
-| U1 | Request for narrative-first, non-sterile persona outputs | user instruction | story-first structure and tone | no org-specific metrics supplied |
-| U2 | v2.5 stance (`F-02` included; details provisional) | user instruction | scope framing and contract posture | informs guidance boundaries |
+| Attribute | Detail |
+| --- | --- |
+| Age | 41 |
+| Location | Boston, hybrid, three days on site |
+| Education | BS Biology, later a regulatory affairs certification |
+| Role | Director, Clinical Quality Operations |
+| Company size | 900 employees, mid-size regulated device manufacturer |
+| Team | Six direct reports, mix of quality specialists and document controllers |
+| Reports to | VP Regulatory Affairs, skip level to Chief Quality Officer |
+| Stakeholders | Clinical operations, regulatory submissions, external auditors, occasionally legal |
+| Purchasing role | Influencer. She does not sign, but a veto from her ends an evaluation |
+| Accessibility | Works across two monitors with dense tables; increases browser zoom in late-day review sessions and loses layouts that assume a fixed viewport |
 
-### LLM-discovered references
-| ID | Resource | Type | Access method | Used for | Reliability notes |
-|---|---|---|---|---|---|
-| L1 | NN/g persona guidance | article | browse/search | decision-oriented persona framing | strong UX source |
-| L2 | NN/g personas + JTBD relationship | article | browse/search | jobs-to-decision linkage | strong conceptual source |
-| L3 | GOV.UK research guidance | docs | browse/search | evidence and assumptions clarity | high-practicality source |
-| L4 | ISO 9241-210 HCD principles | standard summary | browse/search | context-driven design baseline | standards-aligned framing |
+**Career stage and trajectory.** Rhea moved from bench science into quality operations a decade ago and has built her reputation on submissions that survive inspection without findings. She is being positioned for a VP role, and the thing that would most damage that path is a preventable audit finding traced to a process she owned. That shapes every tool decision she makes: she is not evaluating for personal efficiency, she is evaluating for defensibility.
 
-### Evidence gaps and follow-up questions
-| Gap ID | Missing support | Impacted claims/sections | Confidence impact | Follow-up question |
-|---|---|---|---|---|
-| G1 | No current re-open-after-approval baseline | decision model and risk prioritization | Medium | What is current re-open rate by workflow stage? |
-| G2 | No reviewer-confidence distribution by role | mode-specific behavior and risk triage | Medium | Which reviewer cohorts show highest variance? |
-| G3 | No exception taxonomy frequency data | exception governance priorities | Medium | What are top recurring exception classes and owners? |
+**Organizational leverage.** Her influence exceeds her title. Nothing ships without her gate, so when she declines to approve, timelines move and executives hear about it. That leverage is also a burden: teams route around her when they can, which means she often learns about a shortcut after it has already been taken.
 
-### Claim mapping
-| Claim ID | Claim summary | Evidence IDs | Confidence | Assumptions |
-|---|---|---|---|---|
-| C1 | Defensible flow is prioritized over fragile speed | U1, U2, L1, L2 | Medium | regulated review constraints are material |
-| C2 | Decision-quality signals are a core product lever | U1, L2, L3 | Medium | current approval model under-signals quality |
-| C3 | Hidden policy logic harms trust under pressure | U1, L1, L4 | Medium | teams depend on legible escalation paths |
+---
+
+## 2. Technology & Environment Context
+
+| Tool | Role |
+| --- | --- |
+| The approval workflow product | Where submissions are routed, reviewed, and gated |
+| Regulated document management system | System of record for controlled documents; the destination her packages must satisfy |
+| Slack | Where the real negotiation happens, and where approvals get informally pre-agreed before they appear in the tool |
+| Spreadsheet exception tracker | Her personal shadow system for exceptions the product does not model well |
+| Audit-log export | What she actually reaches for when a decision is questioned months later |
+
+**Digital fluency level.** Rhea is fluent in regulated systems and comfortable with structured data, filters, and exports. She is not a scripter and will not build an integration. She understands state machines and permission models conceptually because her job depends on them, so she asks precise questions about what a status actually means and is unsatisfied by vague answers.
+
+**Adoption and abandonment patterns.** She evaluates a tool by trying to break its audit story: she will approve something, then immediately try to reconstruct why. If the reconstruction is hard, the tool is disqualified regardless of how good the daily workflow feels. She abandons quietly, by building a spreadsheet alongside the product rather than complaining, which means her dissatisfaction is invisible until the shadow system is entrenched.
+
+**Work environment.** Dense information, high interruption, and long sessions clustered around submission deadlines. She reviews in focused blocks early morning and in fragmented pockets late in the day, and the late-day fragments are exactly when high-impact approvals arrive.
+
+---
+
+## 3. Jobs to Be Done
+
+**Functional.** When a submission package reaches the final gate, she needs to determine whether every high-impact decision is supported and owned, so that she can approve without carrying unresolved risk into a regulated filing.
+
+**Emotional.** When she signs, she wants to feel that she could defend the decision cold, without context, so that approving does not create a low-grade dread that surfaces every time an audit is scheduled.
+
+**Social.** She wants to be seen as the person who makes shipping safe rather than the person who makes shipping slow. The social cost of being read as an obstacle is real, and it is why she looks for ways to say yes with conditions instead of no.
+
+**Underlying.** The deeper job is converting distributed, informal judgment into something that survives the loss of context. Everyone else's job ends at the decision; hers begins there. She is not managing a workflow, she is managing the future readability of decisions made by people who will have moved on.
+
+---
+
+## 4. Goals & Motivations
+
+**Life goal.** To be the person whose systems hold up under scrutiny, and to reach a VP role on the strength of a record with no preventable findings.
+
+**Approve high-impact items with complete rationale.** She wants every consequential approval to carry its reasoning at the moment it is made. This demands that the product distinguish high-impact from routine and require more at the higher tier, rather than treating a rationale field as universally optional.
+
+**Close every exception with a named owner.** She wants exceptions to be temporary by construction. This demands that the product model owner, reason, expiry, and follow-up as required fields rather than free text, and that it surface exceptions approaching expiry.
+
+**Reconstruct any decision in under ten minutes.** She wants to answer an auditor's question without a forensic exercise. This demands durable evidence links and an export that carries the same context the working view had.
+
+**Feel proportionate rather than uniformly heavy.** She wants the friction concentrated where risk is, so routine approvals move quickly.
+
+**Feel informed before she is asked.** She wants to learn about a problem from the product, not from a stakeholder in a hallway.
+
+**Feel confident in the export.** She wants what leaves the system to match what she saw when she approved it.
+
+---
+
+## 5. Behavioral Patterns & Mental Models
+
+**Core mental model.** Rhea thinks in terms of a chain of custody for decisions, not a workflow. Each approval is a link, and the question she asks of any link is whether it will hold when pulled on later. She does not experience a status field as information; she experiences it as a claim someone made, and her instinct is to ask who made it and on what basis. This is why aggregate status indicators frustrate her disproportionately: a green badge is a summary of claims, and she needs the claims.
+
+**Primary work pattern.** Roughly two thirds reactive, responding to items arriving at her gate, and one third proactive process work she rarely protects successfully. She wants that ratio closer to even, and the reactive share spikes hard in the week before a submission deadline.
+
+**Accuracy and quality approach.** She verifies by sampling rather than exhaustively, choosing samples by risk rather than at random. Good enough means the decision is supported and the support is findable. Her standard does not relax under deadline, but her tolerance for how the support is captured does.
+
+**Tolerance thresholds.** She loses patience with configuration that requires understanding the product's internal model, and with any flow that makes her re-enter context the system already has. She will tolerate significant slowness in exchange for certainty, which is unusual and worth designing around.
+
+---
+
+## 6. Decision-Making & Trust Patterns
+
+**How trust is built and broken.** Trust builds slowly through correct behavior in unremarkable cases and breaks in a single event: one contradictory approval, or one stale evidence link discovered during an audit, moves her permanently to verifying externally. She described a prior tool where one bad export ended her reliance on it entirely, after eighteen months of satisfactory use.
+
+**Adoption filter.** Her implicit checklist runs roughly: can I reconstruct a decision made in this system a year from now, does it distinguish consequential from routine, does what I export match what I saw, and does it make ownership explicit or leave it implied. A tool that fails the first question is disqualified regardless of the rest.
+
+**Risk profile.** Risk-tolerant about process change and risk-averse about evidence. She will pilot a new workflow willingly and will not accept a new system of record without a migration story for historical decisions.
+
+**Feature discovery behavior.** Almost entirely accidental or peer-mediated. She does not read release notes and does not explore. Capability she is not told about directly is capability she does not have.
+
+---
+
+## 7. Workflow & Collaboration Context
+
+**Work rhythm.** Anchored hard to submission deadlines, with the approval load arriving late and compressed. She has perhaps two protected hours early each day and fragmented attention afterward. The riskiest approvals disproportionately arrive during the fragmented window, which is a product problem disguised as a scheduling one.
+
+**Collaboration model.** She is a reviewer and gatekeeper, rarely an author. Her counterparts are clinical and regulatory authors upstream, and auditors and regulators downstream who consume her output long after the fact. That downstream consumer never appears in the product, which is precisely why the product under-serves her.
+
+**Key collaboration friction.** Approvals get informally negotiated in Slack and then recorded in the tool as a formality, so the recorded artifact captures the conclusion and loses the reasoning. She receives a decision with the argument stripped out and is expected to ratify it.
+
+**Dependencies.** She depends on upstream authors to supply complete evidence, on reviewers to apply consistent standards, and on stakeholders to be available for clarification during compressed windows. When a submission slips, she is blamed for the gate rather than the inputs.
+
+---
+
+## 8. Current Alternatives & Workarounds
+
+**Primary alternative.** A personal spreadsheet tracking exceptions, owners, and expiry dates, maintained in parallel with the product. It persists because it models the thing she actually manages, which is the lifecycle of an exception, whereas the product models the moment an exception was granted. It is fragile, unshared, and she knows it is a liability.
+
+**Where the product enters.** It is the system of record for the approval event itself and is trusted for that narrow purpose. Its position is more fragile than usage metrics suggest, because the work she does around it is invisible to the product.
+
+**The firing trigger.** Not one dramatic failure but a pattern: two or three occasions where the product's record could not answer a question she was asked, each pushing more of the real work into the spreadsheet. The tool does not get abandoned, it gets hollowed out.
+
+---
+
+## 9. Pain Points & Unmet Needs
+
+**High-impact approvals recorded without rationale.** The product accepts an approval on a consequential item with no reasoning captured, because the rationale field is optional everywhere. It persists because making it universally required would burden routine approvals, so it stays optional everywhere instead. The cost is paid months later in reconstruction time and, occasionally, in an audit finding.
+
+**Exceptions without owners or expiry.** An exception can be granted under deadline pressure with nothing but a note. It persists because the deadline case is exactly when nobody wants another required field. The cost is a growing population of open exceptions nobody is accountable for, which is the single largest source of her shadow spreadsheet.
+
+**Aggregate status hides unresolved items.** A package shows green while a critical item remains open, because the status rolls up completion rather than risk. It persists because the rollup was designed for progress reporting, not for gating. The cost is a false sense of readiness that reaches Slack before it reaches her.
+
+**Export loses the context of the working view.** What she reviewed and what leaves the system are assembled by different logic, so the export can omit rationale or resolve a link differently. It persists because the two paths were built at different times. The cost is that her audit artifact is not the thing she approved.
+
+**Stale evidence links.** A link that resolved at approval time points somewhere else, or nowhere, months later. It persists because links are stored as references without snapshots. The cost is direct: it is the failure mode most likely to produce an actual finding.
+
+**Contradictory approvals go undetected.** Two reviewers can approve incompatible states of the same item without the system noticing. It persists because approvals are recorded per item rather than evaluated for coherence. The cost is discovered late, usually by her, usually at the gate.
+
+---
+
+## 10. Success Definition & Quality Bar
+
+**Accuracy standard.** Zero tolerance on evidence and ownership, and pragmatic tolerance on presentation. A decision may be recorded tersely; it may not be recorded without a basis.
+
+**Timeliness standard.** On time means the gate does not become the reason for a slip. She measures her own performance partly by how rarely she is the critical path, which is why she is more receptive to proportional friction than to uniform speed.
+
+**Self-sufficiency standard.** A successful output stands alone. Someone with no context should be able to open the record and understand what was decided, by whom, on what basis, and what remains open.
+
+**Quality bar by context.** In normal operation she expects full rationale on high-impact items and light-touch recording elsewhere. In deadline compression she will accept abbreviated rationale in exchange for explicit exception governance: owner, reason, expiry, and follow-up become non-negotiable precisely when everything else relaxes. In an incident or audit response the bar inverts entirely, and reconstruction speed dominates everything, including her willingness to tolerate an awkward interface.
+
+---
+
+## 11. Design Principles & Tradeoff Heuristics
+
+**Legibility over brevity.** When a status could be shorter or more explicable, choose explicable. Her entire job is answering questions about decisions after the context is gone.
+
+**Proportional friction over uniform friction.** When adding a required field, add it at the high-impact tier rather than everywhere. Uniform requirements get satisfied uniformly badly, which destroys the signal on the items that matter.
+
+**Explicit ownership over inferred ownership.** When the system could infer an owner from context, require one instead. An inferred owner is not an owner when the exception is questioned.
+
+**Structured exceptions over free-text exceptions.** When accommodating an edge case under deadline, model it with owner, reason, expiry, and follow-up rather than a comment field. The comment field is where her shadow spreadsheet comes from.
+
+**Parity over convenience.** When the working view and the export could diverge for implementation convenience, keep them identical. A divergence here converts her audit artifact into a guess.
+
+**Risk rollup over completion rollup.** When summarizing package state, summarize by unresolved risk rather than percentage complete. A green completion bar over an open critical item is worse than no summary at all.
+
+**Snapshot over reference.** When linking evidence, capture what was seen at approval time rather than a pointer that resolves later. This is the difference between a record and a hope.
+
+---
+
+## Evidence & Confidence
+
+| Source | Type | Detail |
+| --- | --- | --- |
+| I1-I5 | Interview | Five quality and compliance operations leads at regulated manufacturers, 45-60 minutes each, 2026-06 to 2026-07 |
+| S1 | Support | 14 months of support tickets tagged approvals or exceptions, 312 tickets reviewed and themed |
+| A1 | Analytics | Audit-log export analysis across 4 customer tenants: rationale-field completion by impact tier |
+| W1 | Session recording | Three recorded submission-gate sessions, observed rather than self-reported |
+
+**Validated.** The behavioral model in sections 5 and 6, the exception-lifecycle pain point, and the export-parity failure are supported by converging evidence across interviews, support tickets, and the audit-log analysis. The shadow-spreadsheet workaround appeared unprompted in four of five interviews.
+
+**Assumed.** The demographic detail in section 1 is composite rather than observed. The quality-bar shifts in section 10 come from interview self-report and have not been observed under real deadline compression, which is exactly the condition where self-report is least reliable. Validating that would require observing a live submission window rather than asking about one.
+
+**Open questions.** What is the current re-open-after-approval rate by workflow stage, and does it concentrate in the late-day fragmented window as the behavioral model predicts? Which reviewer cohorts show the widest variance in rationale quality, and is variance driven by role or by time pressure? What are the recurring exception classes by frequency, and who actually owns them today?
+
+**Governance.** Review every two quarters, or immediately after any audit finding touching the approval chain. Retire when the regulated-workflow segment falls below a quarter of new revenue, or when a successor persona based on observed rather than self-reported deadline behavior supersedes it. Next planned research: observe one live submission window, target 2026-10-31.


### PR DESCRIPTION
First two of the three field-reported defects from the 2026-08-01 end-to-end run, ruled into v2.33.0 as candidate C-14. Both were verified against the tree before being worked, and both are fixed at the shape the reporter suggested.

Closes #251
Closes #252

## `foundation-persona` 2.6.1: the example contradicted its own template

`references/EXAMPLE.md` demonstrated a "Layer 1: Narrative Persona Dossier / Layer 2: Operational Appendix" structure whose sections (`Opening scene`, `What they say vs what they mean`, `Completeness Floors`) appear nowhere in `references/TEMPLATE.md`, which mandates a Persona Card plus numbered sections 1 through 11.

An agent loading both references got two canonical formats and no signal which one wins. The reporter's own run resolved it correctly by following SKILL.md's pointer to the Output Contract, and named the real risk precisely: that resolution costs tokens, and a weaker model could ship the non-conforming format and silently violate the contract downstream skills consume.

**The persona is preserved, not replaced.** Rhea Patel, the regulated approval-chain owner, is re-rendered into the mandated structure, so the authored substance survives the format correction. That was the objection recorded against this option at the decision stage, and re-rendering answers it.

Verified structurally rather than by eye:

| Check | Result |
|---|---|
| Template sections present | 13 of 13 |
| Sections added beyond the template | 0 |
| Authoring blockquotes leaked into the example | 0 |
| Unfilled placeholders remaining | 0 |

It also gains the YAML frontmatter every other skill's example carries and this one lacked, which was a second deviation from house convention that nothing had caught.

**Patch, not minor:** the required contract is unchanged and only the example was brought into line with it, per the "examples improved" row of the versioning table.

## `define-prioritization-framework` 1.3.0: three calibration fixes

From a real 8-item backlog in a solo-maintainer context at roughly five hours a week. The report was positive about the skill overall and singled out the convergence and divergence analysis as its most valuable output, which makes this calibration evidence rather than a complaint.

**The top and bottom highlight rule was unsatisfiable below 10 items.** It read "highlight the top 5 and bottom 5"; with 8 items, 5 and 5 overlap or exhaust the list, so the rule could not be followed as written and the run had to improvise a substitute. At 10 or fewer items the skill now shows every item in rank order and describes the gap between clear tiers.

**The RICE Effort unit had no scaling guidance.** It was fixed as eng-weeks or person-weeks. For a solo operator with five hours a week, a notional 40-hour week makes every small item round to "under one week", which flattens the Effort dimension and quietly removes a quarter of the RICE model. The unit is now capacity-weeks, sized to what a week actually buys that team, with the conversion stated in the output.

**The Kano gate was ambiguous about evidence quality.** It asked for "customer-research input" without saying whether summarized signals qualified or whether formal Kano question pairs were required, so the run proceeded on summarized research and self-imposed a confidence flag the skill never asked for. Kano now has explicit tiers:

| Tier | Evidence | Behavior |
|---|---|---|
| Surveyed | Functional and dysfunctional question pairs per feature | Classify normally, label `Kano (surveyed)` |
| Inferred | Interview themes, survey means, support patterns, analytics | Classify, label `Kano (inferred)`, treat a Delighter or Must-Have call as a hypothesis to confirm |

Refusal is now reserved for having no customer research at all. Downgrading the tier and saying so is more useful to a user than excluding the framework.

**Minor, not patch:** the tiering lets the skill run a case it previously refused or fudged and adds an optional tier label to the output, which is additive under the versioning tie-breaker.

## Verification

- 416 of 416 tests
- Pre-tag validator bundle: ALL CHECKS PASSED
- `gen-derived-surfaces --check` current; manifest and AGENTS catalog regenerated for both version changes
- Frontmatter lint OK; the new example frontmatter parses as YAML
- Em-dash gate clean

## Not in this PR

The third field report, #253 (partial-install dead pointers), is WS-3 and lands separately. Its shape was ruled at the decision stage against the drafted recommendation: only `skills/<name>/` ships to an installed agent, so no repo-root file can carry the convention, and the fix is scoped to the 14 skills that mandate a handoff rather than all 35 that name a sibling.
