### PR TITLE
fix(skills): routed skills degrade gracefully when the destination is not installed

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -28,6 +28,8 @@ npx skills add product-on-purpose/pm-skills
 
 Installs all 68 skills into your agent's default skills directory via the open [skills CLI](https://github.com/vercel-labs/skills). No clone, no sync.
 
+The CLI's `--skill` flag installs individual skills instead of the whole library, which is supported. Note that skills route to each other: a build-risk review ends by sending you to a hypothesis skill, a survey analysis points at experiment design. Skills that route as part of their output detect a missing destination and inline the minimum version of it rather than leaving a dead pointer, but the handoffs are seamless only with the full library. Installing a subset works best when you take the skills a routing table sends you to as well.
+
 ### Claude.ai / Claude Desktop
 
 1. Go to **Settings > Capabilities** (Desktop) or **Project Settings > Add Files** (Claude.ai)

--- a/README.md
+++ b/README.md
@@ -323,6 +323,14 @@ The open [skills CLI](https://github.com/vercel-labs/skills) from Vercel Labs sc
 
 Telemetry is anonymous and opt-out via `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1`.
 
+> **Installing a subset?** The CLI's `--skill` flag lets you take individual skills rather than the
+> whole library, and that is a supported way to use pm-skills. Be aware that skills route to each
+> other: a build-risk review ends by sending you to a hypothesis skill, a survey analysis points at
+> experiment design, and so on. Skills that route as part of their output now detect a missing
+> destination and inline the minimum version of it instead of leaving you a dead pointer, but the
+> full library is where the handoffs are seamless. If you are installing a subset, take the skills
+> a routing table sends you to as well as the one you came for.
+
 **Git Clone (manual path, everything included)**
 
 ```bash

--- a/scripts/data/quickstart-fragment.md
+++ b/scripts/data/quickstart-fragment.md
@@ -25,6 +25,8 @@ npx skills add product-on-purpose/pm-skills
 
 Installs all {{SKILLS}} skills into your agent's default skills directory via the open [skills CLI](https://github.com/vercel-labs/skills). No clone, no sync.
 
+The CLI's `--skill` flag installs individual skills instead of the whole library, which is supported. Note that skills route to each other: a build-risk review ends by sending you to a hypothesis skill, a survey analysis points at experiment design. Skills that route as part of their output detect a missing destination and inline the minimum version of it rather than leaving a dead pointer, but the handoffs are seamless only with the full library. Installing a subset works best when you take the skills a routing table sends you to as well.
+
 ### Claude.ai / Claude Desktop
 
 1. Go to **Settings > Capabilities** (Desktop) or **Project Settings > Add Files** (Claude.ai)

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -31,6 +31,8 @@ npx skills add product-on-purpose/pm-skills
 
 Installs all 68 skills into your agent's default skills directory via the open [skills CLI](https://github.com/vercel-labs/skills). No clone, no sync.
 
+The CLI's `--skill` flag installs individual skills instead of the whole library, which is supported. Note that skills route to each other: a build-risk review ends by sending you to a hypothesis skill, a survey analysis points at experiment design. Skills that route as part of their output detect a missing destination and inline the minimum version of it rather than leaving a dead pointer, but the handoffs are seamless only with the full library. Installing a subset works best when you take the skills a routing table sends you to as well.
+
 ### Claude.ai / Claude Desktop
 
 1. Go to **Settings > Capabilities** (Desktop) or **Project Settings > Add Files** (Claude.ai)

--- a/skill-manifest.json
+++ b/skill-manifest.json
@@ -270,7 +270,7 @@
     {
       "name": "discover-journey-map",
       "description": "Maps a customer journey across stages, touchpoints, emotional curve, pain points, and moments of truth into a markdown artifact with an optional mermaid timeline or flowchart. Use when synthesizing existing research into the shape of a customer's experience, end-to-end or for one phase. Without research signal yet, run discover-interview-synthesis or measure-survey-analysis first; refuses to fabricate emotional or behavioral data.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "group": "phase",
       "phase": "discover",
       "family": null,
@@ -315,7 +315,7 @@
     {
       "name": "foundation-build-risk-review",
       "description": "Runs a fast pre-build risk review on a product idea, feature request, or scope change, naming the single assumption most likely to make it fail and returning a clear verdict (build small, validate first, pivot first, or don't build yet) with a no-code validation step. Use before committing build effort, when triaging whether to honor a feature request, or when deciding whether to expand scope, ahead of writing a PRD. For a launched product's pivot-or-persevere decision, use iterate-pivot-decision instead.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "group": "foundation",
       "phase": null,
       "family": null,
@@ -615,7 +615,7 @@
     {
       "name": "measure-survey-analysis",
       "description": "Analyze survey results into actionable PM insights. Produces persona segmentation, hypothesis validation status, thematic clustering of open-text responses, statistical confidence labels, prioritized recommendations, and what-NOT-to-conclude warnings. Refuses to overstate statistical significance from weak samples or biased instruments.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "group": "phase",
       "phase": "measure",
       "family": null,

--- a/skills/define-prioritization-framework/HISTORY.md
+++ b/skills/define-prioritization-framework/HISTORY.md
@@ -17,6 +17,8 @@ Field-reported calibration ([#252](https://github.com/product-on-purpose/pm-skil
 
 **Kano gains explicit evidence tiers.** The applicability gate asked for "customer-research input" without saying whether summarized signals qualified or whether formal Kano question pairs were required. It now distinguishes a surveyed tier (functional and dysfunctional pairs per feature, classify normally) from an inferred tier (interview themes, survey means, support patterns; classify, label as inferred, and treat a Delighter or Must-Have call as a hypothesis to confirm). Refusal is reserved for having no customer research at all, since downgrading the tier and saying so is more useful than excluding the framework.
 
+**Kano unlock suggestion no longer leaves a bare pointer** ([#253](https://github.com/product-on-purpose/pm-skills/issues/253), folded into this same unreleased version). When Kano is excluded for having no research at all, the refusal suggests `discover-interview-synthesis` or `measure-survey-analysis` to unlock it. Under a partial install neither may exist, so the refusal now names the research in plain language as a fallback: roughly 20 to 30 responses asking, per feature, how the user would feel if it were present and if it were absent.
+
 Minor rather than patch: the Kano tiering lets the skill run a case it previously refused or fudged, and adds an optional tier label to the output, which is additive behavior under the versioning tie-breaker.
 
 ## 1.2.0 (2026-07-05)

--- a/skills/define-prioritization-framework/SKILL.md
+++ b/skills/define-prioritization-framework/SKILL.md
@@ -152,7 +152,7 @@ You refuse to produce a ranking without minimum input quality. Specifically:
 
 5. **Single-stakeholder weighted scoring.** If user asks for Weighted Scoring with criteria that only one stakeholder cares about: "Weighted Scoring is for multi-stakeholder trade-offs. If only one stakeholder's criteria apply, RICE or ICE would be simpler. Want to proceed or switch?"
 
-6. **Kano without customer research.** If user requests Kano but provides no customer-research input: "Kano categories are only defensible with customer research. Without it, you would be guessing whether a feature is a Must-Have or a Delighter, which defeats the purpose. I have excluded Kano from this run. The other applicable frameworks have run above. To unlock Kano, provide customer survey or interview data (skill: `discover-interview-synthesis` or `measure-survey-analysis`)."
+6. **Kano without customer research.** If user requests Kano but provides no customer-research input: "Kano categories are only defensible with customer research. Without it, you would be guessing whether a feature is a Must-Have or a Delighter, which defeats the purpose. I have excluded Kano from this run. The other applicable frameworks have run above. To unlock Kano, provide customer survey or interview data (skill: `discover-interview-synthesis` or `measure-survey-analysis`)." If neither skill is available in the environment, do not leave the pointer bare: name the research in plain language instead, which is roughly 20 to 30 responses asking, per feature, how the user would feel if it were present and how they would feel if it were absent.
 
 ## Framework details
 

--- a/skills/discover-journey-map/HISTORY.md
+++ b/skills/discover-journey-map/HISTORY.md
@@ -2,9 +2,16 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 1.3.0 | 2026-08-16 | v2.33.0 | C-14 | minor | Single-touchpoint refusal no longer leaves a bare pointer when the suggested alternative skill is not installed; describes the work in plain language instead (#253). |
 | 1.2.0 | 2026-07-05 | v2.31.0 | WS-Z5 | minor | Reciprocal When NOT to Use pointer to `utility-mermaid-diagrams`; collision pair declared with new trigger fixtures. |
 | 1.1.0 | 2026-07-04 | v2.30.0 | M-35 | minor | Combined bump per skill-versioning.md's tie-breaker rule: added a "When NOT to Use" section, normalized the "Output Format" heading to canon spelling, and rewrote the frontmatter description to name a sibling deflection. All three changes landed across separate stages of this release and share one version bump (implementation plan Section 4). |
 | 1.0.0 | 2026-05-21 | v2.18.0 | - | baseline | Prior published version: produces a customer journey map covering stages, touchpoints, emotional curve, pain points, moments of truth, and opportunity annotations, refusing to fabricate emotional or behavioral data without research input. |
+
+## 1.3.0 (2026-08-16)
+
+Partial-install resilience ([#253](https://github.com/product-on-purpose/pm-skills/issues/253)). The single-touchpoint refusal offered `deliver-edge-cases` as the alternative artifact, which is a dead pointer when the library is installed in part. The refusal now says so when the skill is unavailable and describes the alternative in plain language instead: enumerate the flow's failure and boundary conditions, one row per condition, with the expected handling for each.
+
+Minor rather than patch: the refusal path handles a scenario it previously could not.
 
 ## 1.2.0 (2026-07-05)
 

--- a/skills/discover-journey-map/SKILL.md
+++ b/skills/discover-journey-map/SKILL.md
@@ -4,7 +4,7 @@ description: Maps a customer journey across stages, touchpoints, emotional curve
 license: Apache-2.0
 metadata:
   phase: discover
-  version: "1.2.0"
+  version: "1.3.0"
   updated: 2026-07-05
   category: research
   frameworks: [triple-diamond, service-design]
@@ -160,7 +160,7 @@ You refuse to produce a journey map without minimum input quality. Specifically:
 
 4. **Excessive scope.** End-to-end journey for a long-lifecycle product (e.g., 5 years of B2B SaaS engagement) is too coarse to be useful. Refuse: "End-to-end over 5 years is too coarse. Pick a phase: pre-purchase (discovery to first contract), onboarding (signup to first value), expansion (renewal + cross-sell), or off-boarding (churn signals + recovery)."
 
-5. **Single touchpoint as the whole journey.** If user provides only one touchpoint (e.g., "checkout"): "A single touchpoint isn't a journey. Either expand to the surrounding stages (e.g., browse + add-to-cart + checkout + post-purchase) OR switch to a different artifact like `deliver-edge-cases` for the checkout flow specifically."
+5. **Single touchpoint as the whole journey.** If user provides only one touchpoint (e.g., "checkout"): "A single touchpoint isn't a journey. Either expand to the surrounding stages (e.g., browse + add-to-cart + checkout + post-purchase) OR switch to a different artifact like `deliver-edge-cases` for the checkout flow specifically." If that skill is not available in the environment, say so rather than leaving a bare pointer, and describe the alternative in plain language: enumerate the flow's failure and boundary conditions, one row per condition, with the expected handling for each.
 
 ## Patterns
 

--- a/skills/foundation-build-risk-review/HISTORY.md
+++ b/skills/foundation-build-risk-review/HISTORY.md
@@ -2,8 +2,19 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 1.1.0 | 2026-08-16 | v2.33.0 | C-14 | minor | Verdict routing gains a not-installed fallback: name the gap and inline the minimum for each routed skill, so a review never ships a next step the user cannot execute (#253). |
 | 1.0.1 | 2026-07-04 | v2.30.0 | M-35 | patch | Heading normalized to the skeleton-canon spelling: "When to use" to "When to Use", "When NOT to use" to "When NOT to Use", bare "Output" to "Output Format", "Quality checklist" to "Quality Checklist". |
 | 1.0.0 | 2026-06-22 | v2.29.0 | F-56 | baseline | Prior published version: fast pre-build risk review naming the single assumption most likely to make a product idea or scope change fail, with a verdict and a no-code validation step. |
+
+## 1.1.0 (2026-08-16)
+
+Field-reported ([#253](https://github.com/product-on-purpose/pm-skills/issues/253)). This skill was the reporter's exact reproduction: they installed a subset of the library, ran the review to a "Validate first" verdict, and the artifact shipped mandating `define-hypothesis` then `measure-experiment-design`, neither of which existed in their environment.
+
+The library is routinely installed in part rather than whole, and the install CLI copies only the skill directories it is asked for, so a routed skill may simply not be there. Until now the routing table assumed the full catalog.
+
+Verdict routing now carries a not-installed fallback: when the routed skill cannot be confirmed available, say so plainly and inline the minimum version of its output, with a per-skill table giving that minimum (a hypothesis in believe/for/will/as-measured-by form, a three-line experiment sketch, a two-sentence problem frame, the three riskiest lean-canvas boxes, or a single ranked list). The governing line is that a verdict whose next step the user cannot execute is not a finished review.
+
+Minor rather than patch: the skill now handles a scenario it previously could not, and the output gains an optional section, which is additive under the versioning tie-breaker.
 
 ## 1.0.1 (2026-07-04)
 

--- a/skills/foundation-build-risk-review/SKILL.md
+++ b/skills/foundation-build-risk-review/SKILL.md
@@ -4,7 +4,7 @@ description: Runs a fast pre-build risk review on a product idea, feature reques
 license: Apache-2.0
 metadata:
   classification: foundation
-  version: "1.0.1"
+  version: "1.1.0"
   updated: 2026-07-04
   category: problem-framing
   frameworks: [triple-diamond, lean-startup]
@@ -73,6 +73,22 @@ Be skeptical but useful. Always separate "can be built" from "should be built". 
 | Several competing requests | `define-prioritization-framework` |
 
 Full map, including the per-risk routing: `references/routing-map.md`.
+
+**If a routed skill is not available, do not ship a bare pointer.** The library is often installed
+in part rather than whole, so the skill you route to may not exist in the user's environment. When
+you cannot confirm it is available, say so plainly and inline the minimal version of its output so
+the review stays executable:
+
+| Routed skill absent | Inline instead |
+|---|---|
+| `define-hypothesis` | One testable hypothesis in believe / for / will / as-measured-by form |
+| `measure-experiment-design` | A three-line experiment sketch: the one decision metric, the sample or duration needed, and the win/lose rule set before running |
+| `define-problem-statement` | A two-sentence problem frame: who, in what situation, blocked by what |
+| `foundation-lean-canvas` | The three riskiest boxes only: problem, customer segment, unfair advantage |
+| `define-prioritization-framework` | A single ranked list with the one criterion that actually decides |
+
+A verdict whose next step the user cannot execute is not a finished review. Naming the gap and
+supplying the minimum is always better than routing into an environment that cannot follow.
 
 ## Output Format
 

--- a/skills/measure-survey-analysis/HISTORY.md
+++ b/skills/measure-survey-analysis/HISTORY.md
@@ -2,9 +2,16 @@
 
 | Version | Date | Release | Effort | Type | Summary |
 |---------|------|---------|--------|------|---------|
+| 1.3.0 | 2026-08-16 | v2.33.0 | C-14 | minor | Causal-inference refusal no longer leaves a bare pointer when the suggested experiment-design skill is not installed; states the minimum experiment in plain language instead (#253). |
 | 1.2.0 | 2026-07-05 | v2.31.0 | WS-Z5 | minor | Reciprocal When NOT to Use pointers to `discover-journey-map` and `measure-experiment-results`; collision pairs declared with new trigger fixtures. |
 | 1.1.0 | 2026-07-04 | v2.30.0 | M-35 | minor | Added a "When NOT to Use" section with a reciprocal pointer back to `discover-interview-synthesis`, which already deflected here without a return edge. Closes a one-way gap in the cross-skill reciprocity mesh flagged by the 2026-07-04 deep audit. Also normalized the "Output format" and "Quality checklist" headings to their canon spelling (WS-T8b, no re-bump). |
 | 1.0.0 | 2026-05-21 | v2.18.0 | - | baseline | Prior published version: analyzes survey results into persona segmentation, hypothesis validation, open-text thematic clustering, qualitative confidence labels, and prioritized recommendations, with explicit what-the-data-does-NOT-show warnings. |
+
+## 1.3.0 (2026-08-16)
+
+Partial-install resilience ([#253](https://github.com/product-on-purpose/pm-skills/issues/253)). The causal-inference refusal pointed at `measure-experiment-design`, which is a dead pointer when the library is installed in part. The refusal now says so when the skill is unavailable and states the minimum in plain language instead: one decision metric, a control and a treatment group, the sample size the effect requires, and a win/lose rule fixed before the test runs.
+
+Minor rather than patch: the refusal path handles a scenario it previously could not.
 
 ## 1.2.0 (2026-07-05)
 

--- a/skills/measure-survey-analysis/SKILL.md
+++ b/skills/measure-survey-analysis/SKILL.md
@@ -4,7 +4,7 @@ description: Analyze survey results into actionable PM insights. Produces person
 license: Apache-2.0
 metadata:
   phase: measure
-  version: "1.2.0"
+  version: "1.3.0"
   updated: 2026-07-05
   category: research
   frameworks: [triple-diamond, quantitative-research]
@@ -147,7 +147,7 @@ You refuse to overstate statistical significance from weak data. Specifically:
 
 4. **NPS as decision input.** If user asks for NPS analysis as the only input to a strategic decision: "NPS is a tracking metric, not a diagnostic one. It tells you the trend; it does not tell you what to do. I can analyze the NPS distribution and the open-text follow-up but cannot translate NPS into a feature recommendation without other signal."
 
-5. **Causal inference from a cross-sectional survey.** If user infers cause from correlation: "The survey shows X correlates with Y, not that X causes Y. Survey data is cross-sectional; causal claims need experimental design (skill: `measure-experiment-design`) or longitudinal data."
+5. **Causal inference from a cross-sectional survey.** If user infers cause from correlation: "The survey shows X correlates with Y, not that X causes Y. Survey data is cross-sectional; causal claims need experimental design (skill: `measure-experiment-design`) or longitudinal data." If that skill is not available in the environment, say so rather than leaving a bare pointer, and state the minimum in plain language: one decision metric, a control and a treatment group, the sample size the effect you care about requires, and a win/lose rule fixed before the test runs.
 
 6. **Demanding a single number.** If user asks "what percent want feature X?" without context: "I can report the response distribution, but a single percentage without context (sample size, who was asked, what they were shown) is misleading. Want the full distribution with caveats, or a different framing?"
 


### PR DESCRIPTION
Third and last of the field-reported defects from the 2026-08-01 end-to-end run (C-14 in the v2.33.0 scope).

Closes #253

## The defect

The reporter installed a subset of the library, ran `foundation-build-risk-review` to a **Validate first** verdict, and received an artifact mandating `define-hypothesis` then `measure-experiment-design`. Neither existed in their environment. The routing content was good; it just assumed the whole catalog was present.

## The scope was wrong three times before it was right

Worth showing, because the first three answers were each confidently wrong in a different direction:

| Measurement | Count | Why it was wrong |
|---|---|---|
| Keyword grep for routing verbs | 3 | Far too narrow |
| Any skill naming any sibling | 66 | Far too broad: most are `When NOT to Use` boundary pointers, which degrade harmlessly to "the user does not use X" |
| Siblings named outside the boundary section | 35 | Better, still counting prose mentions |
| Imperative verb near a sibling name | 14 | Noisy: "shared with `foundation-meeting-brief`" and "produced by `foundation-okr-writer`" are not handoffs |
| Sibling named inside an output, routing, or refusal section | 7 | Two are `Project Memory Contract` hits about reading memory, not routing |
| **Genuinely affected** | **4** | One already carries the discipline |

**The four include both skills the reporter named**, which is the corroboration that the measurement converged rather than drifted.

## What changed

**`foundation-build-risk-review` 1.1.0**, the exact repro. Verdict routing gains a not-installed fallback with a per-skill table of the minimum to inline instead: a hypothesis in believe/for/will/as-measured-by form, a three-line experiment sketch, a two-sentence problem frame, the three riskiest lean-canvas boxes, or a single ranked list. The governing line is that **a verdict whose next step the user cannot execute is not a finished review**.

**`discover-journey-map` 1.3.0**, **`measure-survey-analysis` 1.3.0**, and the Kano unlock path in `define-prioritization-framework` (folded into its unreleased 1.3.0): refusal messages that named a skill now detect its absence and state the work in plain language instead of leaving a bare pointer.

## A prior-art correction

I earlier claimed `utility-pm-workflow-orchestrator` already handled a missing skill. **It does not.** It handles missing *tools* (file write, Bash); my grep matched on "unavailable".

The real prior art is `foundation-prioritized-action-plan`'s **Name safety (no guessing)** rule, which already says to describe the next step in plain language when a skill name cannot be confirmed. This change generalizes that instinct from "cannot confirm the name" to "cannot confirm it is installed", which is why that skill needed no edit.

## Front door

README gains a partial-install note. QUICKSTART is generator-owned end to end, so the note went into `scripts/data/quickstart-fragment.md` and renders to both `QUICKSTART.md` and the site quickstart. Hand-editing the rendered files would have failed the generator check.

## Verification

- 416 of 416 tests
- Pre-tag validator bundle: ALL CHECKS PASSED
- `gen-derived-surfaces --check` current; manifest, AGENTS catalog, and both quickstarts regenerated
- Em-dash gate clean