### PR TITLE
docs(front-door): make project memory discoverable, and usable once found

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -70,6 +70,24 @@ If you get a generic response instead of a structured artifact, the agent has no
 
 See `AGENTS.md` for the complete command list.
 
+### Optional: project memory
+
+Skills start cold by default, so each one asks for your phase, your initiative, and anything an earlier skill already produced. Record it once instead.
+
+Add `.claude/pm-skills.local.md` to your `.gitignore` first, then create it:
+
+```yaml
+---
+schema: 1
+phase: discover
+active_initiative: "Self-serve onboarding"
+---
+```
+
+Eight skills read it. The handoff worth trying: run `discover-interview-synthesis`, confirm the entry it offers to record, then run `deliver-prd` and watch it use the personas you already produced instead of asking for them again.
+
+Nothing happens until the file exists, and writes are proposed for your confirmation rather than applied. Full schema and the list of participating skills: [Hooks and project memory](https://product-on-purpose.github.io/pm-skills/concepts/hooks/#project-memory-opt-in).
+
 ### Workflows
 
 Run multi-skill workflows:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ git clone https://github.com/product-on-purpose/pm-skills.git
 - [Setup by Platform](https://product-on-purpose.github.io/pm-skills/getting-started/platforms/) - Step-by-step install for Claude.ai, Codex, Cursor, Windsurf, GitHub Copilot, VS Code extensions, and ChatGPT.
 - [Quickstart Reference](https://product-on-purpose.github.io/pm-skills/getting-started/quickstart/) - Short-form reference card for users who just need the commands.
 
+### Optional: let the skills remember your project
+
+By default every skill starts cold, so you re-supply your phase, your current initiative, and anything a previous skill already produced. You can record that once instead.
+
+Add `.claude/pm-skills.local.md` to your `.gitignore`, then create it:
+
+```yaml
+---
+schema: 1
+phase: discover
+active_initiative: "Self-serve onboarding"
+---
+```
+
+Eight skills now read it. The moment worth seeing: run `discover-interview-synthesis` on your research, confirm the entry it offers to record, then run `deliver-prd`. It uses the personas you already produced rather than asking you to paste them again.
+
+Nothing happens until you create the file, and writes are proposed for your confirmation rather than applied. Full schema, the list of participating skills, and the limits it does not yet cover: [Hooks and project memory](https://product-on-purpose.github.io/pm-skills/concepts/hooks/#project-memory-opt-in).
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ---

--- a/scripts/data/quickstart-fragment.md
+++ b/scripts/data/quickstart-fragment.md
@@ -67,6 +67,24 @@ If you get a generic response instead of a structured artifact, the agent has no
 
 See `AGENTS.md` for the complete command list.
 
+### Optional: project memory
+
+Skills start cold by default, so each one asks for your phase, your initiative, and anything an earlier skill already produced. Record it once instead.
+
+Add `.claude/pm-skills.local.md` to your `.gitignore` first, then create it:
+
+```yaml
+---
+schema: 1
+phase: discover
+active_initiative: "Self-serve onboarding"
+---
+```
+
+Eight skills read it. The handoff worth trying: run `discover-interview-synthesis`, confirm the entry it offers to record, then run `deliver-prd` and watch it use the personas you already produced instead of asking for them again.
+
+Nothing happens until the file exists, and writes are proposed for your confirmation rather than applied. Full schema and the list of participating skills: [Hooks and project memory](https://product-on-purpose.github.io/pm-skills/concepts/hooks/#project-memory-opt-in).
+
 ### Workflows
 
 Run multi-skill workflows:

--- a/site/src/content/docs/concepts/hooks.md
+++ b/site/src/content/docs/concepts/hooks.md
@@ -46,7 +46,7 @@ The hook fires on Claude's tool calls, not on what you type by hand, so it only 
 
 ## Configuring guardrails
 
-Guardrails are controlled by a gitignored, per-project file, `.claude/pm-skills.local.md`, with YAML frontmatter. With no file, nothing happens. To enable them:
+Guardrails are controlled by a per-project file, `.claude/pm-skills.local.md`, with YAML frontmatter. Add it to your `.gitignore` before creating it: it is local configuration, and once project memory is in use it also holds your initiative and recorded decisions. With no file, nothing happens. To enable them:
 
 ```yaml
 ---
@@ -84,9 +84,44 @@ flowchart TD
 
 ## Project memory (opt-in)
 
-Skills normally start cold: every session you re-supply which phase you are in, what you are working on, and what you already produced. Project memory lets a project record that once, in the same gitignored `.claude/pm-skills.local.md` the guardrails and router already use, so the catalog compounds across a session instead of restarting.
+Skills normally start cold: every session you re-supply which phase you are in, what you are working on, and what you already produced. Project memory lets a project record that once, in the same `.claude/pm-skills.local.md` the guardrails and router already use, so the catalog compounds across a session instead of restarting.
 
 **It is inert unless you create the file.** With no file, every skill and both hooks behave exactly as they did before, which is the whole trust posture: nothing reads or writes your project until you ask it to.
+
+### Turning it on
+
+1. **Ignore the file first.** Add `.claude/pm-skills.local.md` to your project's `.gitignore` before you create it. It will hold your current initiative, recorded decisions, and paths to internal artifacts, which is not usually content you want in version control, and in a public repository is content you almost certainly do not. Nothing ignores it for you.
+2. **Create it** with the two keys that do the work:
+
+   ```yaml
+   ---
+   schema: 1
+   phase: discover
+   active_initiative: "Self-serve onboarding"
+   ---
+   ```
+
+3. **Run a skill that reads it.** Start a session and run `discover-interview-synthesis` on your research. When it finishes it will offer to record what it produced. Confirm.
+4. **Run the next skill.** Run `deliver-prd`. It reads the personas the previous skill recorded instead of asking you to paste them again. That handoff is the whole feature; everything else is plumbing that makes it safe.
+
+Update `phase` as you move through the Triple Diamond. The router reads it at session start and stops guessing from your branch name.
+
+### Which skills read it
+
+Eight skills carry a `## Project Memory Contract` as of v2.33.0. Anything not on this list ignores the file entirely.
+
+| Skill | Reads | Writes |
+|---|---|---|
+| `discover-interview-synthesis` | initiative | personas and findings, as `interpretation` |
+| `deliver-prd` | initiative, prior `interpretation` artifacts | the PRD as `decision`, plus scope and metrics to `## Decisions` |
+| `foundation-okr-writer` | initiative, prior artifacts | the OKR set as `decision` |
+| `iterate-retrospective` | initiative, prior artifacts | lessons as `interpretation` |
+| `foundation-meeting-agenda` | initiative | nothing; an agenda plans a meeting that has not happened |
+| `foundation-meeting-brief` | initiative | nothing; the brief is preparation |
+| `foundation-meeting-recap` | initiative | decisions reached, plus the recap as `decision` |
+| `foundation-meeting-synthesize` | initiative | the synthesis as `interpretation` |
+
+The two pure readers are deliberate. The meeting family already chains its own artifacts by filename, so memory carries durable product context across meetings rather than duplicating a mechanism that works.
 
 ```yaml
 ---
@@ -154,7 +189,7 @@ The distinction is load-bearing rather than decorative: it is what lets a reader
 
 **Concurrent writes: what is guaranteed, and what is not.** Every contract that writes carries a **Write discipline** bullet requiring the skill to re-read the file immediately before writing, merge its entry into current state rather than overwriting, and re-propose if the file changed since the proposal was drafted. The `check-memory-contracts` validator enforces that a writing contract states this.
 
-What that buys is an *instruction*, not a guarantee. Nothing enforces it at runtime: a skill is text an agent follows, the agent chooses its own edit primitive, and the validator checks the declaration rather than the resulting file. So the honest position is that two sessions writing the same file are now told how to avoid clobbering each other, and are not prevented from it. The file is gitignored, so a bad write is not recoverable through git. Eight skills ship a contract in v2.32.0, six of which write; treat the file as a convenience that compounds context, not as a system of record.
+What that buys is an *instruction*, not a guarantee. Nothing enforces it at runtime: a skill is text an agent follows, the agent chooses its own edit primitive, and the validator checks the declaration rather than the resulting file. So the honest position is that two sessions writing the same file are now told how to avoid clobbering each other, and are not prevented from it. If you have ignored the file as recommended, a bad write is not recoverable through git either. Eight skills ship a contract, six of which write; treat the file as a convenience that compounds context, not as a system of record.
 
 ## Output-quality checks (advisory CI)
 

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -73,6 +73,24 @@ If you get a generic response instead of a structured artifact, the agent has no
 
 See `AGENTS.md` for the complete command list.
 
+### Optional: project memory
+
+Skills start cold by default, so each one asks for your phase, your initiative, and anything an earlier skill already produced. Record it once instead.
+
+Add `.claude/pm-skills.local.md` to your `.gitignore` first, then create it:
+
+```yaml
+---
+schema: 1
+phase: discover
+active_initiative: "Self-serve onboarding"
+---
+```
+
+Eight skills read it. The handoff worth trying: run `discover-interview-synthesis`, confirm the entry it offers to record, then run `deliver-prd` and watch it use the personas you already produced instead of asking for them again.
+
+Nothing happens until the file exists, and writes are proposed for your confirmation rather than applied. Full schema and the list of participating skills: [Hooks and project memory](https://product-on-purpose.github.io/pm-skills/concepts/hooks/#project-memory-opt-in).
+
 ### Workflows
 
 Run multi-skill workflows:

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -224,6 +224,22 @@ deliver-acceptance-criteria "User can reset password via email"
 
 [Full setup guide](getting-started/) · [Find the right skill](guides/skill-finder.md) · [Recipes](guides/recipes.md)
 
+### Optional: let the skills remember your project
+
+Every skill starts cold by default, so you re-supply your phase, your initiative, and whatever a previous skill already produced. Record it once instead. Add `.claude/pm-skills.local.md` to your `.gitignore`, then create it:
+
+```yaml
+---
+schema: 1
+phase: discover
+active_initiative: "Self-serve onboarding"
+---
+```
+
+Eight skills read it. The moment worth seeing: run `discover-interview-synthesis` on your research, confirm the entry it offers to record, then run `deliver-prd`. It uses the personas you already produced instead of asking you to paste them again.
+
+Nothing happens until you create the file, and writes are proposed for your confirmation rather than applied. [Full schema, participating skills, and current limits](concepts/hooks.md#project-memory-opt-in)
+
 ## See It In Action
 
 Follow three fictional companies through the complete product lifecycle - from discovery research to pivot decisions - with real prompts and full outputs.


### PR DESCRIPTION
WS-4 of the v2.33.0 user-facing cut. v2.32.0 shipped project memory as its headline and **no front-door surface mentioned it**.

Auditing before writing the pointers found the destination was not ready either, so this fixes the documentation before advertising it.

## A defect, not just a gap

The docs described the state file as "gitignored" in two places. That is a property of **this repo's** `.gitignore` (line 71, `.claude/*`), not of the file.

**No document anywhere told a user to ignore it in their own project.** So someone following the docs creates a file holding their current initiative, recorded decisions, and paths to internal artifacts, commits it, possibly to a public repository, while the documentation assures them it is ignored.

Both claims are corrected, and every entry point now says to gitignore it **first**, before creating it.

## Three usability gaps, measured rather than guessed

| Gap | Before | After |
|---|---|---|
| Which skills participate | "Eight skills ship a contract" and none were named; the only skill name in the section was inside a YAML sample | A table naming all eight with what each reads and writes, and why two are pure readers |
| Getting started | No sequence at all | Four steps ending at the payoff, not the schema |
| The central claim | Described, never demonstrated | Every entry point carries the concrete handoff |

The getting-started sequence is deliberately four steps that end at the point of the feature: ignore the file, create it, run `discover-interview-synthesis`, then run `deliver-prd` and watch it reuse the personas you already produced. That last step is the whole feature; everything else is plumbing that makes it safe.

## Four surfaces

| Surface | How |
|---|---|
| `README.md` | New section under Quick Start |
| `site/src/content/docs/index.mdx` | Same, under its Quick Start |
| `QUICKSTART.md` | Generator-owned end to end |
| Site quickstart | Generator-owned end to end |

The last two render from `scripts/data/quickstart-fragment.md`, so the content went there. Hand-editing either rendered file would have failed `gen-derived-surfaces --check`, since lines 3 to 117 of QUICKSTART sit inside a `pmskills:` marker.

## Verification

- 416 of 416 tests
- Pre-tag validator bundle: ALL CHECKS PASSED
- Site builds at 417 pages; rendered links, route parity, and edit links all pass
- `gen-derived-surfaces --check` current
- Em-dash gate clean

## Not in this PR

WS-5, the worked memory example in `library/`, is the remaining half of C-4. This PR makes the feature findable and usable; WS-5 demonstrates it end to end on one of the three canonical sample threads.