### PR TITLE
docs(samples): worked project-memory handoff on the Storevine thread

### DIFF
--- a/library/skill-output-samples/README_SAMPLES.md
+++ b/library/skill-output-samples/README_SAMPLES.md
@@ -1,6 +1,6 @@
 ﻿# PM Skills Sample Library
 
-210 sample outputs across 63 PM skills of the current 68-skill catalog. The 5 sub-agent dispatch skills have their samples at `library/sub-agent-samples/` instead of here. v2.18.0 added 12 samples across the 4 new phase skills (discover-market-sizing, define-prioritization-framework, discover-journey-map, measure-survey-analysis). Organized into three narrative threads that follow fictional product teams through the full Triple Diamond lifecycle plus the v2.15.0 Foundation Sprint and Design Sprint families. Each sample is a complete, realistic artifact that shows what a PM team would produce when invoking a pm-skills slash command against a real product context. Utility skills have single-thread samples (storevine) demonstrating their meta-skill outputs. Meeting-family skills (foundation-meeting-*) have three samples per skill (one per thread) following the SAMPLE_CREATION.md thread standards. Sprint-family skills (tool-foundation-sprint-* and tool-design-sprint-*) also have three samples per skill, with each thread carrying a coherent end-to-end FS+DS arc. Certain phase skills carry additional legacy and orbit samples beyond the canonical thread trio for historical calibration.
+212 sample outputs across 63 PM skills of the current 68-skill catalog. The 5 sub-agent dispatch skills have their samples at `library/sub-agent-samples/` instead of here. v2.18.0 added 12 samples across the 4 new phase skills (discover-market-sizing, define-prioritization-framework, discover-journey-map, measure-survey-analysis). Organized into three narrative threads that follow fictional product teams through the full Triple Diamond lifecycle plus the v2.15.0 Foundation Sprint and Design Sprint families. Each sample is a complete, realistic artifact that shows what a PM team would produce when invoking a pm-skills slash command against a real product context. Utility skills have single-thread samples (storevine) demonstrating their meta-skill outputs. Meeting-family skills (foundation-meeting-*) have three samples per skill (one per thread) following the SAMPLE_CREATION.md thread standards. Sprint-family skills (tool-foundation-sprint-* and tool-design-sprint-*) also have three samples per skill, with each thread carrying a coherent end-to-end FS+DS arc. Certain phase skills carry additional legacy and orbit samples beyond the canonical thread trio for historical calibration.
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@
 
 ## What Is This?
 
-This folder contains 210 sample outputs (126 pre-v2.15.0 + 45 v2.15.0 Sprint Skills additions + 12 v2.18.0 content-skill additions + 3 v2.23.0 foundation addition + 18 v2.28.0 foundation addition + 3 v2.29.0 foundation addition):
+This folder contains 212 sample outputs (126 pre-v2.15.0 + 45 v2.15.0 Sprint Skills additions + 12 v2.18.0 content-skill additions + 3 v2.23.0 foundation addition + 18 v2.28.0 foundation addition + 3 v2.29.0 foundation addition + 2 v2.33.0 project-memory pair):
 
 **Pre-v2.15.0 (126 samples):**
 
@@ -55,7 +55,7 @@ This folder contains 210 sample outputs (126 pre-v2.15.0 + 45 v2.15.0 Sprint Ski
 
 - **3 foundation-build-risk-review samples** - 1 per thread (storevine bulk price-update feature request, brainshelf AI auto-tagging idea, workbench enterprise knowledge-base bet); each a Build Risk Review with a single biggest risk, a graded evidence ledger, a verdict, and a no-code validation step
 
-75 + 11 + 12 + 3 + 7 + 15 + 3 + 21 + 21 + 3 + 12 + 3 + 18 + 3 = 207 itemized; the on-disk corpus is 210 (a few older samples predate this itemized breakdown).
+75 + 11 + 12 + 3 + 7 + 15 + 3 + 21 + 21 + 3 + 12 + 3 + 18 + 3 + 2 = 209 itemized; the on-disk corpus is 212 (a few older samples predate this itemized breakdown).
 
 The samples serve two purposes:
 
@@ -134,7 +134,7 @@ For machine-readable per-thread metadata (identity, stage, prompt style, charact
 
 ## Browse by Skill
 
-Each row links to three sample outputs for the same skill, one per thread. The foundation-persona skill has expanded coverage: 4 samples per thread (product brief, product detailed, marketing brief, marketing detailed) to demonstrate both modes at both depth levels.
+Each row links to three sample outputs for the same skill, one per thread, with two documented exceptions. The foundation-persona skill has expanded coverage: 4 samples per thread (product brief, product detailed, marketing brief, marketing detailed) to demonstrate both modes at both depth levels. And `discover-interview-synthesis` and `deliver-prd` each carry a second Storevine sample, suffixed `_sms-optin`, which together demonstrate the project-memory handoff: the synthesis records its personas, and the PRD written afterward reads them instead of having them pasted in. Read the two Prompt blocks side by side; that contrast is the point of the pair.
 
 | Phase | Skill | What It Produces | Storevine | Brainshelf | Workbench |
 |-------|-------|-----------------|-----------|------------|-----------|

--- a/library/skill-output-samples/THREAD_PROFILES.md
+++ b/library/skill-output-samples/THREAD_PROFILES.md
@@ -379,6 +379,21 @@ The `<additional-helpful-context>` segment varies by sample type:
 Lowercase, hyphen-separated, no spaces. Validators pin these rules and
 reject filenames that violate them.
 
+**Sort hazard when a skill gains a second sample on the same thread.** The site's
+`loadSkillSamples()` in `scripts/gen-site.mjs` sorts the directory and takes the
+FIRST match per thread for a skill's Real-World Examples block. A suffix that
+extends the canonical arc name therefore displaces the canonical sample, because
+`-` (0x2D) sorts before `.` (0x2E):
+
+| Second sample named | Sorts before `_campaigns.md`? | Effect on the skill page |
+|---|---|---|
+| `_campaigns-sms-optin.md` | Yes | The sub-feature sample silently replaces the canonical one |
+| `_sms-optin.md` | No | Canonical sample stays; the second is reachable from the samples index |
+
+Both forms are permitted by the table above, so prefer a bare feature suffix
+when adding a second sample to a thread a skill already covers. Verified
+empirically 2026-08-16 while adding the `_sms-optin` project-memory pair.
+
 ## Adding a New Thread
 
 The current three threads cover the B2B / consumer / enterprise archetype

--- a/library/skill-output-samples/deliver-prd/sample_deliver-prd_storevine_sms-optin.md
+++ b/library/skill-output-samples/deliver-prd/sample_deliver-prd_storevine_sms-optin.md
@@ -1,0 +1,170 @@
+---
+title: "PRD: Storevine SMS Opt-In (Campaigns v2)"
+description: "Storevine B2B ecommerce platform - SMS opt-in PRD written against project memory, so the prompt supplies scope and constraints rather than re-pasting the research."
+artifact: prd
+version: "1.0"
+repo_version: "2.33.0"
+skill_version: "2.2.0"
+created: 2026-08-16
+status: sample
+thread: storevine
+context: Storevine B2B ecommerce platform - Campaigns v2 SMS opt-in PRD, second half of a two-sample project-memory handoff
+---
+<!-- PM-Skills | https://github.com/product-on-purpose/pm-skills | Apache 2.0 -->
+
+## Scenario
+
+Same initiative as `sample_discover-interview-synthesis_storevine_sms-optin.md`, one step later. The six merchant interviews are done and the synthesis has been recorded.
+
+**Project memory now carries that synthesis**, which is the whole point of this sample. `.claude/pm-skills.local.md` in the Storevine repo reads:
+
+```yaml
+---
+schema: 1
+phase: deliver
+active_initiative: "Campaigns v2: SMS opt-in"
+artifacts:
+  - skill: discover-interview-synthesis
+    title: "Storevine SMS opt-in: merchant interview synthesis"
+    path: docs/research/sms-optin-synthesis.md
+    produced: 2026-08-16
+    provenance: interpretation
+    summary: "6 merchants; consent ownership is the blocker, bundled opt-in is a non-starter, 10DLC registration is the abandonment point, sender separation is wanted"
+---
+```
+
+The operator has changed `phase` from `discover` to `deliver` and left the artifact entry alone.
+
+**What to compare.** The v1 email PRD in this same directory, `sample_deliver-prd_storevine_campaigns.md`, opens with a 32-line prompt that re-states the platform, the merchant count, the competitive position, the discovery findings, and the personas, because the skill had no way to know any of it. The prompt below is 11 lines and contains none of that. It supplies only what memory cannot know: the scope decision, the timeline, and the constraints the PM is imposing. The Target Users section further down is populated from the recorded synthesis rather than from the prompt.
+
+That difference is the feature. Everything else in this sample is an ordinary PRD.
+
+**Source Notes:**
+
+- The CTIA Messaging Principles and Best Practices (ctia.org) require express written consent for marketing SMS, retained and auditable, which is the basis for the consent-record requirements below.
+- 10DLC brand and campaign registration (the Campaign Registry, and carrier documentation) is a prerequisite for application-to-person throughput in the US and can be rejected, which is why registration is modeled as a tracked multi-day state rather than a form.
+- The TCPA (47 U.S.C. 227) provides statutory damages per non-consented marketing message, which is the liability that makes consent ownership a product claim rather than a setting.
+
+---
+
+## Prompt
+
+```
+deliver-prd
+
+Feature: SMS opt-in for Campaigns v2.
+
+Scope decision: opt-in and consent only this release. No campaign composer, no
+automation, no segmentation. Those are v2.1.
+
+Timeline: 10 weeks to GA.
+
+Constraints: SMS must use a separate sender from email, and we are not shipping
+a bundled email-plus-SMS consent checkbox under any circumstance.
+```
+
+---
+
+## Output
+
+# PRD: SMS Opt-In (Campaigns v2)
+
+## Overview
+
+**Problem.** Storevine deferred SMS from Campaigns v1 because it requires carrier compliance, opt-in flows, and separate sending infrastructure, and shipping it alongside email would have concentrated launch risk. Campaigns v1 is now stable, and the deferred work is the next constraint on the initiative.
+
+**What this release does.** It ships the consent layer only: collecting SMS opt-in, proving it, and completing 10DLC registration. It does not ship the ability to send a marketing campaign. That capability lands in v2.1 on top of this foundation.
+
+**Why consent first.** The recorded discovery is unambiguous that consent is the adoption blocker rather than a configuration step. Merchants are not asking for a consent feature; they are asking the platform to own the consent obligation and to be able to prove it under audit. Shipping a composer on top of an unowned consent record would ship the capability without moving adoption.
+
+**Target Users.** Drawn from the recorded interview synthesis rather than re-derived here:
+
+- **Compliance-blocked non-adopters.** Merchants who have declined SMS specifically over consent liability, including one whose legal review rejected a vendor over its consent record. This is the largest segment in the research and the one this release is scoped for.
+- **Considered-and-stopped merchants.** Merchants who evaluated SMS more than once and stopped at the bundled-consent question. They are addressable without any new capability, only a credible consent story.
+- **Standalone-provider switchers.** Merchants already paying for SMS elsewhere who keep it separate deliberately. Their stated switching condition is that the consent record transfers or is re-collected cleanly.
+
+## Goals & Success Metrics
+
+| Goal | Metric | Target |
+|---|---|---|
+| Merchants complete registration rather than abandoning it | Share of merchants who start 10DLC registration and reach an approved or explicitly-rejected terminal state | 85% [fictional] |
+| Consent is provable | Time for a merchant to export a full consent record for one subscriber | Under 2 minutes [fictional] |
+| The bundled-consent objection is neutralized | Share of surveyed compliance-blocked merchants who say consent is no longer their blocker | 60% [fictional] |
+| Email is not put at risk | Email deliverability change attributable to SMS launch | No measurable change |
+
+The registration-completion metric is the primary decision metric. The research identified registration as the only observed abandonment point, so it is the one number that determines whether this release worked.
+
+## User Stories
+
+- As a compliance-anxious merchant, I want to see who holds the SMS consent record and how I export it, so that I can answer my own legal review before I enable anything.
+- As a merchant with an existing email list, I want SMS consent collected separately from email consent, so that I am not relying on a bundled checkbox I believe is unlawful.
+- As a merchant starting 10DLC registration, I want to see what stage it is at and how long it typically takes, so that silence does not read as failure.
+- As a merchant whose registration is rejected, I want to know why and what to change, so that rejection is a step rather than an ending.
+- As a merchant already using a standalone SMS provider, I want to import or cleanly re-collect my consent records, so that switching does not mean losing my list.
+- As a merchant who has spent effort on email deliverability, I want SMS to send from separate infrastructure, so that a new channel cannot damage the sender reputation I built.
+
+## Scope
+
+**In scope.** SMS consent collection as a standalone opt-in, consent record storage with retention and export, 10DLC brand and campaign registration as a tracked workflow with status and a rejection path, separate SMS sending infrastructure provisioned and isolated from email, and a consent-record import path for merchants switching from a standalone provider.
+
+**Out of scope, deliberately.** Campaign composition, scheduling, automation, segmentation, templates, and analytics. All are v2.1. Also out: non-US jurisdictions, since the recorded research covers 10DLC and TCPA obligations only and no participant operated outside the US.
+
+**Explicitly rejected.** A bundled email-plus-SMS consent checkbox. Four of six research participants raised bundled consent unprompted as disqualifying, and one abandoned a competing plugin over exactly that pattern. Offering it as an option would deter the segment this release targets.
+
+## Solution Design
+
+**Consent as an owned record.** Each SMS opt-in produces an immutable consent record capturing the phone number, the timestamp, the collection surface, the exact consent language shown, and the merchant it belongs to. Records are retained for the statutory period and exportable per subscriber or in bulk. The product states plainly, in the merchant-facing UI, that Storevine holds and retains this record.
+
+**Separate opt-in surface.** SMS consent is collected on its own control with its own language, never as an additional checkbox on an existing email form. Where both are offered on one page, they are visibly distinct controls with independent state, and neither pre-checks the other.
+
+**Registration as a tracked workflow.** 10DLC brand and campaign registration is modeled as a multi-day state machine with five states: not started, submitted, under review, approved, rejected. Each state shows expected duration. Rejection shows the carrier reason and the specific field to change, and resubmission is a first-class action rather than a restart.
+
+**Sender isolation.** SMS provisioning uses separate infrastructure and separate credentials from email, with no shared reputation surface. This is surfaced to merchants as a stated property, not left as an implementation detail, because the research found merchants actively want the separation preserved.
+
+**Switcher import.** Merchants can upload consent records from a standalone provider with the same required fields. Records missing any required field are rejected at import with the reason, rather than accepted and treated as consented.
+
+## Technical Considerations
+
+Registration status is externally controlled and asynchronous, so the workflow must tolerate multi-day latency, out-of-order webhooks, and silence. Polling is required as a fallback rather than relying on carrier callbacks alone.
+
+Consent records are legal evidence, so they are append-only. Corrections create a superseding record rather than mutating the original, and the export must show the full chain.
+
+The separate sender means a second set of provider credentials, rate limits, and error surfaces. Error handling cannot be shared with the email path.
+
+## Dependencies & Risks
+
+| Item | Type | Note |
+|---|---|---|
+| 10DLC registration approval times | Dependency | Externally controlled, varies, and can reject. The workflow design assumes this rather than treating it as an edge case |
+| SMS provider selection | Dependency | Blocks sender provisioning. Must be settled by week 2 |
+| Statutory retention period per jurisdiction | Risk | Scoped to US only this release; expanding scope later may change retention requirements |
+| Merchants importing unusable consent records | Risk | Mitigated by rejecting at import rather than accepting silently, at the cost of a harder import experience |
+
+## Timeline & Milestones
+
+| Week | Milestone |
+|---|---|
+| 1-2 | Provider selection settled; consent record schema fixed |
+| 3-5 | Consent collection surface and record storage |
+| 6-7 | 10DLC registration workflow including the rejection path |
+| 8 | Switcher import |
+| 9 | Consent export and audit view |
+| 10 | GA |
+
+## Open Questions
+
+- Should consent export be self-serve from day one, or is a support-mediated export acceptable for GA? The research says merchants need to be able to answer legal review, which may not require self-serve.
+- Do we surface expected registration duration as a range or a single figure? A single figure that proves wrong is worse than a range.
+- For switchers, do we require re-consent when an imported record lacks the exact consent language, or accept the record with a flag? This is a legal question, not a product one.
+
+## Appendix
+
+### How this PRD used project memory
+
+The prompt above supplied the scope decision, the timeline, and two constraints. It did not supply the platform, the merchant count, the competitive position, the research findings, or the personas. Those came from the recorded `interpretation` artifact, which is why the Target Users section names three segments the prompt never mentions.
+
+The comparison worth making is with `sample_deliver-prd_storevine_campaigns.md` in this same directory. That PRD covers the email half of the same initiative, and its prompt runs 32 lines because everything the skill needed had to be pasted in. This one runs 11.
+
+### Limitations of this sample
+
+This is a written worked example in the same style as the rest of the corpus, not a transcript of an executed run. It demonstrates the handoff as designed. It does not by itself prove that the propose-then-confirm write mechanic fires correctly at runtime, which is a separate thing to verify.

--- a/library/skill-output-samples/discover-interview-synthesis/sample_discover-interview-synthesis_storevine_sms-optin.md
+++ b/library/skill-output-samples/discover-interview-synthesis/sample_discover-interview-synthesis_storevine_sms-optin.md
@@ -1,0 +1,168 @@
+---
+title: "Discover Interview Synthesis: Storevine SMS Opt-In"
+description: "Storevine B2B ecommerce platform - merchant interviews on SMS marketing, run with project memory enabled so the synthesis is recorded for the PRD that follows."
+artifact: interview-synthesis
+version: "1.0"
+repo_version: "2.33.0"
+skill_version: "2.3.0"
+created: 2026-08-16
+status: sample
+thread: storevine
+context: Storevine B2B ecommerce platform - merchant SMS interviews for the Campaigns v2 opt-in scope, first half of a two-sample project-memory handoff
+---
+<!-- PM-Skills | https://github.com/product-on-purpose/pm-skills | Apache 2.0 -->
+
+## Scenario
+
+Storevine shipped Campaigns v1 (email) and deferred SMS to v2. The shipped v1 PRD records the reason precisely: SMS has high merchant demand but "requires carrier compliance, opt-in flows, and separate sending infrastructure", deferred to isolate launch risk. With v1 stable across roughly 18k active merchants [fictional], the growth PM has re-opened the SMS question and commissioned six merchant interviews to scope what an opt-in-first SMS release would have to handle.
+
+**This run has project memory enabled**, which is what makes it the first half of a pair. The team has created `.claude/pm-skills.local.md` in the Storevine repo and ignored it in git:
+
+```yaml
+---
+schema: 1
+phase: discover
+active_initiative: "Campaigns v2: SMS opt-in"
+---
+```
+
+Nothing else is in the file yet. At the end of this run the skill offers to record its personas and findings as an `interpretation` artifact, the operator confirms, and the file gains its first `artifacts[]` entry. The companion sample, `sample_deliver-prd_storevine_sms-optin.md`, is the PRD written afterward against that recorded context. Reading the two Prompt blocks side by side is the point of the pair: this one supplies the research, and the PRD one does not have to.
+
+**Source Notes:**
+
+- The CTIA Messaging Principles and Best Practices (ctia.org) require express written consent before sending marketing SMS, with the consent record retained and auditable. This is the compliance obligation merchants describe as the reason they have not built SMS themselves.
+- The 10DLC registration regime for application-to-person messaging in the US (documented by the major carriers and the Campaign Registry) requires brand and campaign registration before throughput is granted, which is why "separate sending infrastructure" is a scoping fact rather than a preference.
+- The TCPA (47 U.S.C. 227) establishes statutory damages per message for marketing texts sent without consent, which is the specific liability that makes merchants describe SMS as higher-stakes than email.
+- Nielsen Norman Group research on consent and permission UX (nngroup.com) finds that users interpret bundled consent as coercive and disengage, which bears directly on whether SMS opt-in can share a checkbox with email.
+
+---
+
+## Prompt
+
+```
+discover-interview-synthesis
+
+I ran six merchant interviews about SMS marketing for Campaigns v2. Synthesize
+them into themes, personas, and recommendations that can feed a PRD.
+
+Participants (all current Storevine merchants on Campaigns v1 email):
+- M1, home goods, 3 staff, currently uses a standalone SMS provider
+- M2, apparel, 12 staff, no SMS, considered it twice and stopped
+- M3, supplements, 6 staff, currently uses a standalone SMS provider
+- M4, pet supplies, 2 staff, no SMS, actively worried about compliance
+- M5, outdoor gear, 25 staff, no SMS, has legal review for marketing
+- M6, cosmetics, 8 staff, tried SMS through a plugin and abandoned it
+
+Interview notes are in the attached transcripts. Focus on what an opt-in-first
+release would have to handle. We already know SMS was deferred from v1 for
+carrier compliance, opt-in flows, and separate sending infrastructure; I want
+to know what merchants actually need, not confirmation of that.
+```
+
+---
+
+## Output
+
+# Storevine SMS Opt-In: Interview Synthesis
+
+## Research Overview
+
+### Objective
+
+Determine what an opt-in-first SMS release must handle for Storevine merchants, and whether the v1 deferral reasons map to real merchant blockers or only to platform-side engineering scope.
+
+### Methodology
+
+Six semi-structured interviews, 45 minutes each, conducted remotely over two weeks. Participants were recruited from active Campaigns v1 merchants and deliberately split between current SMS users (2), considered-and-stopped (3), and tried-and-abandoned (1). Transcripts were coded independently by two researchers before theme consolidation.
+
+### Participant Summary
+
+| ID | Vertical | Staff | SMS today | Recruitment basis |
+|---|---|---|---|---|
+| M1 | Home goods | 3 | Standalone provider | Current SMS user |
+| M2 | Apparel | 12 | None | Considered twice, stopped |
+| M3 | Supplements | 6 | Standalone provider | Current SMS user |
+| M4 | Pet supplies | 2 | None | Compliance-blocked |
+| M5 | Outdoor gear | 25 | None | Has legal review |
+| M6 | Cosmetics | 8 | None | Tried a plugin, abandoned |
+
+## Key Themes
+
+### Theme 1: Consent Is the Product, Not a Setting
+
+Every participant who had not adopted SMS described consent as the reason, and none described it as a feature they wanted configured. They described it as a liability they wanted absorbed. M4 and M5 both asked, unprompted, who would hold the consent record if Storevine sent the message. M5's legal review had already declined one SMS vendor over exactly that question. The merchants who did use SMS (M1, M3) had both accepted their provider's consent tooling wholesale rather than customizing it.
+
+The distinction that matters for scope: merchants are not asking for a consent feature. They are asking for the platform to own the consent obligation and to be able to prove it later.
+
+### Theme 2: Bundled Consent Is a Non-Starter, and Merchants Know It
+
+Four participants raised, without being asked, that they did not want SMS consent bundled into the existing email signup. M2 had considered SMS twice and stopped both times at this question, describing a bundled checkbox as "the thing that gets you sued." M6 abandoned a plugin specifically because it added phone collection to the existing email form with one shared checkbox.
+
+This is a stronger signal than it appears. Merchants are declining a shortcut the platform could easily have shipped, which means the constraint is externally imposed and stable rather than a preference the product could argue them out of.
+
+### Theme 3: The Second Sender Is a Reputation Risk, Not Just Infrastructure
+
+M1, M3 and M5 each independently connected SMS to the email deliverability work they had already done. M1 described spending eight months rebuilding sender reputation after a bad list import and said flatly that they would not put that at risk again. M3 kept SMS on a separate provider deliberately, describing it as "not worth mixing." M5 framed it as a governance question: different channel, different consent basis, different audit trail.
+
+This reframes the v1 deferral note. "Separate sending infrastructure" was recorded as a platform engineering cost. Merchants experience the same separation as a desirable property they want preserved.
+
+### Theme 4: Abandonment Happens at Setup, Not at Send
+
+M6 is the only participant who started and stopped. The abandonment point was not sending, cost, or results. It was the registration step: the plugin surfaced 10DLC brand registration as a form with no explanation of what it was, how long it took, or what happened if it was rejected. M6 filled it in, waited, heard nothing, and stopped. Neither M2 nor M4 had reached that step, but both anticipated it as the likely stopping point.
+
+## Notable Quotes
+
+- "I do not want to configure consent. I want to not be the one holding it." (M4)
+- "The bundled checkbox is the thing that gets you sued." (M2)
+- "I spent eight months getting our email reputation back. I am not putting that near a new channel." (M1)
+- "Legal did not say no to SMS. They said no to that vendor's consent record." (M5)
+- "I filled in the registration, waited, and never heard anything. So I stopped." (M6)
+- "We keep SMS separate on purpose. Not worth mixing." (M3)
+
+## Insights
+
+### Insight 1: The Deferral Reasons Were Right, for the Wrong Reason
+
+The v1 PRD deferred SMS for carrier compliance, opt-in flows, and separate sending infrastructure, framed as launch risk to Storevine. The interviews confirm all three matter, but as merchant-side blockers rather than platform-side cost. Compliance is a liability merchants want absorbed, opt-in is a legal exposure they will not bundle, and separate infrastructure is a property they want preserved. A v2 that solves these as engineering problems without addressing the ownership question would ship the capability and not move adoption.
+
+### Insight 2: Registration Is the Real Funnel, and It Is Currently Invisible
+
+The only observed abandonment happened at 10DLC registration, and the two non-adopters furthest along both named it as their expected stopping point. Registration is asynchronous, externally controlled, and can be rejected, which is a shape no other part of Campaigns has. Treating it as a form is what lost M6. It needs status, expected duration, and a rejection path.
+
+### Insight 3: The Existing SMS Users Are a Switching Opportunity, Not a Retention Risk
+
+M1 and M3 both pay a standalone provider and both described the separation as deliberate rather than satisfying. Neither had evaluated switching, because neither knew Storevine intended to offer it. Their stated switching condition was identical: the consent record must transfer or be re-collected cleanly, because losing it means losing the list.
+
+## Recommendations
+
+### Recommendation Details
+
+1. **Make consent ownership an explicit product claim, not an implied one.** State in the product who holds the consent record, how it is retained, and how a merchant exports it under audit. This is the single most repeated ask and it is currently unaddressed.
+2. **Ship SMS consent as a separate opt-in from email, and do not offer a bundled option.** Four of six raised this unprompted, and offering the bundle would actively deter the compliance-sensitive segment.
+3. **Treat 10DLC registration as a tracked, multi-day workflow with visible status and a rejection path.** It is the only observed abandonment point and the anticipated one for two more participants.
+4. **Preserve sender separation between email and SMS, and say so.** Merchants read a shared sender as a risk to work they have already done. The engineering separation the v1 PRD treated as a cost is a feature to name.
+5. **Scope a consent-record import path for switchers.** M1 and M3 are addressable, and both named the consent record as the switching condition.
+
+## Appendix
+
+### Methodology Notes
+
+Participants were compensated. Two researchers coded independently, with themes retained only where both coded the same passage. Quotes are lightly edited for length and de-identified by merchant vertical rather than name.
+
+### Limitations
+
+Six participants across one platform is directional, not representative. The sample deliberately over-weights non-adopters (four of six), which is appropriate for a scoping question but means it under-samples the operational experience of running SMS at volume. No participant operated outside the US, so the findings speak to 10DLC and TCPA obligations only and do not cover jurisdictions with separate consent regimes.
+
+### Project memory entry recorded
+
+At the end of this run the skill proposed the following entry, and the operator confirmed it. This is what the companion PRD sample reads instead of re-collecting the research.
+
+```yaml
+artifacts:
+  - skill: discover-interview-synthesis
+    title: "Storevine SMS opt-in: merchant interview synthesis"
+    path: docs/research/sms-optin-synthesis.md
+    produced: 2026-08-16
+    provenance: interpretation
+    summary: "6 merchants; consent ownership is the blocker, bundled opt-in is a non-starter, 10DLC registration is the abandonment point, sender separation is wanted"
+```

--- a/site/src/content/docs/concepts/hooks.md
+++ b/site/src/content/docs/concepts/hooks.md
@@ -106,6 +106,8 @@ Skills normally start cold: every session you re-supply which phase you are in, 
 
 Update `phase` as you move through the Triple Diamond. The router reads it at session start and stops guessing from your branch name.
 
+**See it worked through.** Two samples in the library demonstrate exactly this handoff on the Storevine thread: [the interview synthesis that records its personas](../samples/discover-interview-synthesis/sample_discover-interview-synthesis_storevine_sms-optin.md) and [the PRD written afterward](../samples/deliver-prd/sample_deliver-prd_storevine_sms-optin.md) that reads them. Compare that PRD's 11-line prompt against the 32-line prompt in [the v1 email PRD](../samples/deliver-prd/sample_deliver-prd_storevine_campaigns.md) covering the same initiative without memory. The difference is entirely context the second prompt did not have to restate.
+
 ### Which skills read it
 
 Eight skills carry a `## Project Memory Contract` as of v2.33.0. Anything not on this list ignores the file entirely.

--- a/site/src/content/docs/samples/index.md
+++ b/site/src/content/docs/samples/index.md
@@ -1,17 +1,17 @@
 ---
 title: Samples
-description: Browse 210 PM artifact samples spanning 63 of the catalog's 68 skills and three product threads (Storevine, Brainshelf, Workbench).
+description: Browse 212 PM artifact samples spanning 63 of the catalog's 68 skills and three product threads (Storevine, Brainshelf, Workbench).
 sidebar:
   order: 1
 ---
 
-The samples corpus contains **210 real PM artifacts** produced by the pm-skills commands, organized by skill and by product thread. Use this section as a "what does the output actually look like?" reference when picking which skill to run, when tuning your prompt style, or when comparing how the same skill behaves across different product contexts.
+The samples corpus contains **212 real PM artifacts** produced by the pm-skills commands, organized by skill and by product thread. Use this section as a "what does the output actually look like?" reference when picking which skill to run, when tuning your prompt style, or when comparing how the same skill behaves across different product contexts.
 
 ## What lives here
 
 | Coverage | Count |
 |----------|-------|
-| Total samples | 210 |
+| Total samples | 212 |
 | Skills with samples | 63 |
 | Product threads | 3 (Storevine, Brainshelf, Workbench) |
 
@@ -25,7 +25,7 @@ Each sample includes the scenario context, the exact prompt that produced it, an
 | **Brainshelf** | Consumer PKM app building Resurface (contextual morning digest) | Post-seed, ~20 employees | Casual: bullet points, shorthand, enough context to work |
 | **Workbench** | Enterprise collaboration building Blueprints (document templates with approval gates) | Series B, ~200 employees | Enterprise: full stakeholder lists, quantified baselines, explicit metrics |
 
-Per-thread sample distribution: Storevine 71, Brainshelf 64, Workbench 64, plus 11 legacy and orbit samples outside the thread trio.
+Per-thread sample distribution: Storevine 73, Brainshelf 64, Workbench 64, plus 11 legacy and orbit samples outside the thread trio.
 
 The threads exist so you can see how the same skill behaves under different product contexts. A `define-hypothesis` sample under Storevine reads differently than one under Workbench, because the scenario inputs (team, scale, prior artifacts, decision tempo) differ. Reading three threads of the same skill is the fastest way to internalize the variation surface of any skill.
 


### PR DESCRIPTION
WS-5 of the v2.33.0 user-facing cut, and the second half of C-4.

v2.32.0 shipped project memory claiming the PRD skill would reuse personas an earlier skill produced. **Nothing in the repo demonstrated it.** Two samples now do.

## The demonstration

| Sample | Role |
|---|---|
| `sample_discover-interview-synthesis_storevine_sms-optin.md` | Records six merchant interviews, ends by writing an `interpretation` artifact to memory |
| `sample_deliver-prd_storevine_sms-optin.md` | The PRD written afterward, reading that artifact |

The PRD's prompt is **11 lines**. The v1 email PRD covering the same initiative without memory runs **32**. Both counts verified against the files, not asserted. The difference is entirely context the second prompt did not have to restate, and the PRD's Target Users section names three segments its prompt never mentions.

## Memory state lives in Scenario, not a fourth section

Plan decision D8-a. `parseSampleSections()` in `gen-site.mjs` returns only `{context, thread, scenario, prompt, output}`, so a fourth `## Project Memory` H2 is **silently dropped** from both the per-skill Real-World Examples block and the showcase.

Scenario is where it belongs anyway: that section describes the situation a skill is invoked in, and "memory already carries these personas" is that situation. Renders everywhere, zero generator change, no documented exception needed.

## The research pass fabricated a quote; the adversarial pass caught it

The spec claimed the v1 PRD defers SMS over *"per-message costs that need a different pricing model than email"*, and built a proposed persona and a prompt constraint on top of it.

The real text: *"requires carrier compliance, opt-in flows, and separate sending infrastructure . deferred to isolate launch risk"*. **No cost or pricing clause exists in the file.** Verified first-hand, not taken from the reviewer.

The personas here are rebuilt on the real reason: compliance-blocked non-adopters, considered-and-stopped merchants, and standalone-provider switchers.

## Two synthesis claims did not survive checking

`THREAD_PROFILES.md` has no section 9.3, and its naming table explicitly permits a bare feature suffix (`_campaign-flow`). So `_sms-optin` is **conforming**, and no naming exception was documented.

## But a real, undocumented hazard turned up while checking that

`loadSkillSamples()` sorts the directory and takes the first match per thread. `-` (0x2D) sorts before `.` (0x2E), so a second sample named `_campaigns-sms-optin.md` would **silently displace** the canonical `_campaigns.md` on the skill page. Both forms are permitted by the naming table.

Verified empirically and now documented in `THREAD_PROFILES.md` with a comparison table, so the next author does not reach for the dangerous form.

## Counts

Updated at every surface, gated and ungated: 210 to 212 in `README_SAMPLES.md` (three spots) and `samples/index.md` (four spots); Storevine 71 to 73, verified with `find` rather than arithmetic. `README_SAMPLES.md` line 137 previously claimed three samples per skill per thread with one exception; it now names two.

## Stated limit

Recorded inside the PRD sample itself: this is a written worked example in the corpus style, not a transcript. It demonstrates the loop **as designed** and does not prove the propose-then-confirm write fires at runtime. That is a separate check.

## Verification

- `check-sample-counts` OK at 212 across 63 skills; sample-coverage PASS
- 416 tests; pre-tag bundle ALL CHECKS PASSED
- Site builds at **419 pages**, up 2; both new sample pages confirmed present in `dist` and the hooks.md links confirmed resolving to them
- Rendered links, route parity, and 404 edit links all pass