### PR TITLE
docs(samples): add develop-adr sample exercising Model Choice

### DIFF
--- a/library/skill-output-samples/README_SAMPLES.md
+++ b/library/skill-output-samples/README_SAMPLES.md
@@ -1,6 +1,6 @@
 ﻿# PM Skills Sample Library
 
-212 sample outputs across 63 PM skills of the current 68-skill catalog. The 5 sub-agent dispatch skills have their samples at `library/sub-agent-samples/` instead of here. v2.18.0 added 12 samples across the 4 new phase skills (discover-market-sizing, define-prioritization-framework, discover-journey-map, measure-survey-analysis). Organized into three narrative threads that follow fictional product teams through the full Triple Diamond lifecycle plus the v2.15.0 Foundation Sprint and Design Sprint families. Each sample is a complete, realistic artifact that shows what a PM team would produce when invoking a pm-skills slash command against a real product context. Utility skills have single-thread samples (storevine) demonstrating their meta-skill outputs. Meeting-family skills (foundation-meeting-*) have three samples per skill (one per thread) following the SAMPLE_CREATION.md thread standards. Sprint-family skills (tool-foundation-sprint-* and tool-design-sprint-*) also have three samples per skill, with each thread carrying a coherent end-to-end FS+DS arc. Certain phase skills carry additional legacy and orbit samples beyond the canonical thread trio for historical calibration.
+213 sample outputs across 63 PM skills of the current 68-skill catalog. The 5 sub-agent dispatch skills have their samples at `library/sub-agent-samples/` instead of here. v2.18.0 added 12 samples across the 4 new phase skills (discover-market-sizing, define-prioritization-framework, discover-journey-map, measure-survey-analysis). Organized into three narrative threads that follow fictional product teams through the full Triple Diamond lifecycle plus the v2.15.0 Foundation Sprint and Design Sprint families. Each sample is a complete, realistic artifact that shows what a PM team would produce when invoking a pm-skills slash command against a real product context. Utility skills have single-thread samples (storevine) demonstrating their meta-skill outputs. Meeting-family skills (foundation-meeting-*) have three samples per skill (one per thread) following the SAMPLE_CREATION.md thread standards. Sprint-family skills (tool-foundation-sprint-* and tool-design-sprint-*) also have three samples per skill, with each thread carrying a coherent end-to-end FS+DS arc. Certain phase skills carry additional legacy and orbit samples beyond the canonical thread trio for historical calibration.
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@
 
 ## What Is This?
 
-This folder contains 212 sample outputs (126 pre-v2.15.0 + 45 v2.15.0 Sprint Skills additions + 12 v2.18.0 content-skill additions + 3 v2.23.0 foundation addition + 18 v2.28.0 foundation addition + 3 v2.29.0 foundation addition + 2 v2.33.0 project-memory pair):
+This folder contains 213 sample outputs (126 pre-v2.15.0 + 45 v2.15.0 Sprint Skills additions + 12 v2.18.0 content-skill additions + 3 v2.23.0 foundation addition + 18 v2.28.0 foundation addition + 3 v2.29.0 foundation addition + 2 v2.33.0 project-memory pair + 1 v2.33.0 Model Choice sample):
 
 **Pre-v2.15.0 (126 samples):**
 
@@ -55,7 +55,7 @@ This folder contains 212 sample outputs (126 pre-v2.15.0 + 45 v2.15.0 Sprint Ski
 
 - **3 foundation-build-risk-review samples** - 1 per thread (storevine bulk price-update feature request, brainshelf AI auto-tagging idea, workbench enterprise knowledge-base bet); each a Build Risk Review with a single biggest risk, a graded evidence ledger, a verdict, and a no-code validation step
 
-75 + 11 + 12 + 3 + 7 + 15 + 3 + 21 + 21 + 3 + 12 + 3 + 18 + 3 + 2 = 209 itemized; the on-disk corpus is 212 (a few older samples predate this itemized breakdown).
+75 + 11 + 12 + 3 + 7 + 15 + 3 + 21 + 21 + 3 + 12 + 3 + 18 + 3 + 2 = 209 itemized; the on-disk corpus is 213 (a few older samples predate this itemized breakdown).
 
 The samples serve two purposes:
 
@@ -271,6 +271,7 @@ The Brainshelf thread follows the PM team building **Resurface**, a contextual m
 | Develop | [solution-brief](develop-solution-brief/sample_develop-solution-brief_brainshelf_resurface.md) | Brainshelf Resurface: contextual daily brief based on recent reading patterns |
 | Develop | [spike-summary](develop-spike-summary/sample_develop-spike-summary_brainshelf_resurface.md) | Article extraction quality: Diffbot vs. Mercury Parser vs. Readability.js vs. custom |
 | Develop | [adr](develop-adr/sample_develop-adr_brainshelf_resurface.md) | ADR: Mercury Parser selected (open source, no API cost, sufficient fidelity) |
+| Develop | [adr](develop-adr/sample_develop-adr_brainshelf_topic-matching-model.md) | ADR: OpenAI text-embedding-3-small selected for Resurface topic matching, with the reversal cost of the pgvector index recorded |
 | Develop | [design-rationale](develop-design-rationale/sample_develop-design-rationale_brainshelf_resurface.md) | Email digest + in-app card chosen over push notification for resurface delivery |
 | Deliver | [prd](deliver-prd/sample_deliver-prd_brainshelf_resurface.md) | PRD: Brainshelf Resurface with Apple Mail Privacy handling and privacy review |
 | Deliver | [user-stories](deliver-user-stories/sample_deliver-user-stories_brainshelf_resurface.md) | PM who reads extensively but forgets to revisit saved research |

--- a/library/skill-output-samples/develop-adr/sample_develop-adr_brainshelf_topic-matching-model.md
+++ b/library/skill-output-samples/develop-adr/sample_develop-adr_brainshelf_topic-matching-model.md
@@ -1,0 +1,125 @@
+---
+title: "Develop ADR: Brainshelf Topic-Matching Model"
+description: "Brainshelf consumer PKM app - embedding model decision for the Resurface topic-matching algorithm."
+artifact: adr
+version: "1.0"
+repo_version: "2.33.0"
+skill_version: "2.2.0"
+created: 2026-08-18
+status: sample
+thread: brainshelf
+context: Brainshelf consumer PKM app . embedding model decision for the Resurface topic-matching algorithm
+---
+<!-- PM-Skills | https://github.com/product-on-purpose/pm-skills | Apache 2.0 -->
+
+## Scenario
+
+The Resurface digest picks which saved items to surface by matching a user's recent reading against their archive. The Sprint 7 spike proved the approach worked but left the model question open . the prototype called OpenAI's embedding API because it was the fastest thing to wire up, not because anyone had compared it. With the A/B test scheduled for Sprint 9 and the cost line now visible to Priya M., Alex R. was asked to settle the model choice and write it up before the test locks the pipeline in place.
+
+The team compared three options against retrieval quality on a hand-labelled set, per-item cost at projected archive sizes, and how much of the pipeline would need rebuilding if the model changed later. That last criterion is what pushed this into an ADR rather than a spike note: the embedding dimension propagates into the vector index schema, so the choice is not a line-item swap.
+
+**Source Notes:**
+
+- Michael Nygard, "Documenting Architecture Decisions" (cognitect.com/blog/2011/11/15/documenting-architecture-decisions) . the lightweight ADR format used in this document.
+- OpenAI, "Embeddings" (platform.openai.com/docs/guides/embeddings) . the `text-embedding-3-small` model and its dimension-reduction parameter referenced in the evaluation.
+- Nils Reimers and Iryna Gurevych, "Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks" (arxiv.org/abs/1908.10084) . the sentence-transformers family considered as the self-hosted alternative.
+- Massive Text Embedding Benchmark (huggingface.co/spaces/mteb/leaderboard) . the public retrieval benchmark the team used to shortlist candidates before running their own evaluation.
+
+---
+
+## Prompt
+
+```
+develop-adr
+
+topic matching model for resurface. the spike used openai
+text-embedding-3-small because it was quickest to get running,
+never actually compared anything.
+
+need to lock this before sprint 9 a/b test.
+
+options:
+- openai text-embedding-3-small: what we have. good enough on our
+  eval set. $0.02 per 1M tokens. dimension 1536, can truncate to 512
+- self-host all-MiniLM-L6-v2 on our own box: free per call but
+  someone has to babysit it, and retrieval was noticeably worse on
+  the long-form stuff people actually save
+- cohere embed-v3: slightly better on our set than openai, roughly
+  3x the price, and a second vendor to onboard
+
+the thing marco keeps raising is what happens when we want to switch.
+the vector index is built at whatever dimension we pick.
+
+we're leaning openai but write up what the lock-in actually costs.
+```
+
+---
+
+## Output
+
+# ADR-011: Use OpenAI text-embedding-3-small for Resurface Topic Matching
+
+## Status
+
+Accepted
+
+**Date:** 2026-08-14
+**Deciders:** Alex R. (Engineering Lead), Priya M. (Product Manager), Marco L. (Backend Engineer)
+
+## Context
+
+Resurface selects which archived items to include in a user's morning digest by comparing embeddings of recently read content against embeddings of their saved archive. The Sprint 7 spike established that the approach produces digests users rate as relevant, but the spike used OpenAI's `text-embedding-3-small` for expedience and never evaluated alternatives.
+
+Three constraints shape the decision. First, retrieval quality on long-form saved content . the material Brainshelf users actually archive skews toward articles and essays, not short notes, and a model that performs well on short-text benchmarks may not transfer. Second, per-item cost at projected scale: 22K MAU with a median archive of 340 saved items [fictional] means roughly 7.5M items to embed at backfill [fictional], plus ongoing embedding of new saves at approximately 95K items per week [fictional]. Third, and the reason this is an ADR rather than a spike note, the embedding dimension is written into the pgvector index schema. Changing models later is not a configuration change; it is a re-embed of the entire archive plus an index rebuild.
+
+The team evaluated three candidates against a hand-labelled relevance set of 200 query-archive pairs drawn from internal accounts [fictional].
+
+## Decision
+
+We will use OpenAI's `text-embedding-3-small` for Resurface topic matching, truncated to 512 dimensions via the API's `dimensions` parameter rather than the native 1536.
+
+The truncation is deliberate. On the evaluation set, 512 dimensions cost 1.2 percentage points of top-10 recall against full-dimension output [fictional] while reducing the pgvector index size by roughly two thirds [fictional], which keeps the index in memory on the current database instance. Marco L. will implement the embedding pipeline behind an internal `EmbeddingProvider` interface so that the call site does not name a vendor.
+
+## Consequences
+
+### Positive
+
+- Highest retrieval quality of the three candidates on long-form content: top-10 recall of 0.81 against 0.74 for the self-hosted baseline [fictional]
+- No inference infrastructure to operate; the team of two backend engineers has no ML-ops capacity and the Sprint 9 test date does not allow for building it
+- Backfill cost of approximately $38 one-off [fictional] and ongoing cost of roughly $6 per month at current save volume [fictional] are small enough that cost is not a factor in the A/B test decision
+
+### Negative
+
+- A vendor outage stops new saves from being embedded. Digests still send from previously embedded content, so the failure is degraded relevance rather than a blank email, but it is silent and we will not notice without an explicit alert
+- Sending saved-content text to a third-party API is a new data-flow commitment that did not exist before, and one we will have to describe plainly in the privacy policy before the A/B test opens to external users
+- The team gains no in-house understanding of retrieval quality; when relevance complaints arrive we can tune prompts and thresholds but cannot inspect or adjust the model
+
+### Neutral
+
+- The `EmbeddingProvider` interface keeps the call site vendor-neutral, but as the Model Choice table records, the interface is not where the real coupling lives
+
+### Model Choice
+
+| Consequence | This decision |
+|-------------|---------------|
+| **Build, buy, or prompt** | Buy: call OpenAI's embedding API. Self-hosting `all-MiniLM-L6-v2` was ruled out on retrieval quality for long-form content (0.74 top-10 recall against 0.81 [fictional]) and on having no one to operate it. Cohere `embed-v3` scored marginally higher (0.83 [fictional]) but at roughly 3x cost and a second vendor relationship, which did not clear the bar for 2 points of recall |
+| **What is now coupled to it** | The pgvector index is built at 512 dimensions, so the schema is tied to this choice. Also coupled: the 0.62 similarity threshold that decides digest inclusion, tuned against this model's score distribution, and the 200-pair evaluation set, which is comparable only across models scored the same way. The `EmbeddingProvider` interface abstracts the call, not the index |
+| **Operating cost accepted** | About $38 for the initial backfill and $6 per month ongoing at 95K new saves per week [fictional]. This stops being negligible if archive growth outpaces MAU growth . at roughly 10x current save volume the monthly line reaches a point where the self-hosted option is worth re-costing |
+| **Reversal cost** | Re-embedding 7.5M items and rebuilding the pgvector index: approximately 6 engineer-days plus one maintenance window [fictional], during which Resurface digests degrade to the previous day's selections. The similarity threshold must also be re-tuned, which means re-running the labelled evaluation. The interface makes the code change trivial; the data migration is the cost |
+| **What would reopen this** | Two observations. Digest relevance ratings dropping below 3.5 of 5 [fictional] while prompt and threshold tuning are exhausted, which would mean the model is the ceiling. Or OpenAI deprecating `text-embedding-3-small`, which forces the re-embed regardless and makes it the moment to reconsider the other two |
+
+## Alternatives Considered
+
+### Self-hosted all-MiniLM-L6-v2
+
+Free per call and keeps saved content on our own infrastructure, which is the stronger privacy position. Rejected on two grounds: top-10 recall of 0.74 against 0.81 [fictional] on the evaluation set, with the gap concentrated in exactly the long-form articles that dominate real archives; and no one on a two-engineer backend team to own inference uptime before Sprint 9. Worth revisiting if save volume grows enough to make the cost line material, since the privacy argument survives the quality argument.
+
+### Cohere embed-v3
+
+Best retrieval score of the three at 0.83 top-10 recall [fictional]. Rejected because 2 percentage points of recall did not justify roughly 3x the per-token cost and onboarding a second vendor, including a new data-processing agreement. The margin is small enough to sit inside the noise of a 200-pair evaluation set, so the quality advantage is not firmly established.
+
+## References
+
+- Sprint 7 spike summary: topic-matching algorithm feasibility
+- Resurface A/B test design (Sprint 9)
+- Brainshelf privacy policy . third-party data processor section, pending update

--- a/site/src/content/docs/samples/index.md
+++ b/site/src/content/docs/samples/index.md
@@ -1,17 +1,17 @@
 ---
 title: Samples
-description: Browse 212 PM artifact samples spanning 63 of the catalog's 68 skills and three product threads (Storevine, Brainshelf, Workbench).
+description: Browse 213 PM artifact samples spanning 63 of the catalog's 68 skills and three product threads (Storevine, Brainshelf, Workbench).
 sidebar:
   order: 1
 ---
 
-The samples corpus contains **212 real PM artifacts** produced by the pm-skills commands, organized by skill and by product thread. Use this section as a "what does the output actually look like?" reference when picking which skill to run, when tuning your prompt style, or when comparing how the same skill behaves across different product contexts.
+The samples corpus contains **213 real PM artifacts** produced by the pm-skills commands, organized by skill and by product thread. Use this section as a "what does the output actually look like?" reference when picking which skill to run, when tuning your prompt style, or when comparing how the same skill behaves across different product contexts.
 
 ## What lives here
 
 | Coverage | Count |
 |----------|-------|
-| Total samples | 212 |
+| Total samples | 213 |
 | Skills with samples | 63 |
 | Product threads | 3 (Storevine, Brainshelf, Workbench) |
 


### PR DESCRIPTION
Takes one of the four conditional sections from the issue: **`develop-adr` → `Model Choice`**.

`library/skill-output-samples/develop-adr/sample_develop-adr_brainshelf_topic-matching-model.md`

### Why this scenario justifies the section

The brainshelf thread already has a topic-matching algorithm spike in its Resurface arc, so the decision was sitting there waiting to be written up rather than invented to fit the section. The ADR picks an embedding model for topic matching, which is exactly the case the template's comment describes: *"this decision selects a model, or commits the system to one."*

The section fires because the decision is genuinely a model decision, not because a heading needed filling.

### Following the template's intent, not just its shape

The template is pointed about what makes a model choice different from an ordinary dependency choice: *"the consequence worth writing down is not which model won. It is what the choice costs to undo."*

So the table's centre of gravity is the coupling, and the sample is specific about it: the pgvector index is built at 512 dimensions, the similarity threshold is tuned to one model's score distribution, and the evaluation set is only comparable across models scored the same way. The `EmbeddingProvider` interface abstracts the call site but not the index — the sample says so explicitly, in the Neutral consequence and again in the table, because "we put an interface in front of it" is the comfortable answer that the template is warning against.

`What would reopen this` names two observations rather than a review date, per the template.

### Conventions

- Filename follows `sample_skill_thread_<context>.md`
- brainshelf voice per `THREAD_PROFILES.md`: casual prompt style, bullet-point shorthand, lowercase names in the prompt
- Section order mirrors `skills/develop-adr/references/TEMPLATE.md`, with `Model Choice` as the last subsection of Consequences
- Every invented figure carries `[fictional]`

### Checks

| Script | Result |
|---|---|
| `check-sample-counts` | `sample counts OK (213 sample files across 63 sampled skills)` |
| `check-sample-no-placeholders` | `no placeholder findings.` |
| `check-sample-no-fabricated-metrics` | 338 advisory findings, **identical before and after** — zero from this file |

Counts bumped 212 → 213 in the three places `check-sample-counts.mjs` names across `README_SAMPLES.md` and the site landing page, including the itemized breakdown line. Added the row to the Browse-by-Company table for brainshelf.

Three of the four sections from the issue remain unclaimed.

Closes #280